### PR TITLE
CV2 assertion error while converting crops from cv2 to pillow 

### DIFF
--- a/sports/common/team.py
+++ b/sports/common/team.py
@@ -70,7 +70,7 @@ class TeamClassifier:
         Returns:
             np.ndarray: Extracted features as a numpy array.
         """
-        crops = [sv.cv2_to_pillow(crop) for crop in crops]
+        crops = [sv.cv2_to_pillow(crop) for crop in crops if crop.size != 0]
         batches = create_batches(crops, self.batch_size)
         data = []
         with torch.no_grad():


### PR DESCRIPTION
…any of the crops are empty arrays. Added a check to mitigate the cv2 assertion error

# Description

While conversion of the image crops from cv2 to pillow, cv2 will throw an assertion error if any of the crops are empty. added a check which mitigates this assertion in team.py

 crops = [sv.cv2_to_pillow(crop) for crop in crops **if crop.size != 0**]


List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested on my not so accurate YOLO model on a bad quality video which often sends empty arrays for some reason so the team classifier would often crash while fitting if any empty arrays are being converted to pillow from cv2.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
