### PR TITLE
Add handball court support

### DIFF
--- a/examples/handball/.gitignore
+++ b/examples/handball/.gitignore
@@ -1,0 +1,4 @@
+data/
+notebooks/*.pt
+notebooks/*/
+notebooks/runs/

--- a/examples/handball/README.md
+++ b/examples/handball/README.md
@@ -1,0 +1,111 @@
+# Handball AI
+
+## install
+
+Install from source in a [Python>=3.8](https://www.python.org/) environment.
+
+```bash
+pip install git+https://github.com/roboflow/sports.git
+cd examples/handball
+pip install -r requirements.txt
+./setup.sh
+```
+
+If a notebook fails with `RuntimeError: Numpy is not available`, restart the
+runtime after the install cell finishes, then run the notebook from the top.
+This is caused by PyTorch importing before the notebook pins a NumPy version.
+
+## datasets
+
+| use case                         | dataset                                                                                                                                             | train model                                                                                                                                            |
+|:---------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| handball player detection        | [Handball_Player_Detection](https://universe.roboflow.com/project-k1mun/handball_player_detection)                                                  | [train_player_detector.ipynb](notebooks/train_player_detector.ipynb)                                                                                   |
+| handball ball detection          | [handball-ballon](https://universe.roboflow.com/handballdetection/handball-ballon)                                                                  | [train_ball_detector.ipynb](notebooks/train_ball_detector.ipynb)                                                                                       |
+| handball ball detection          | [ball-only-detection](https://universe.roboflow.com/handball-detection/ball-only-detection)                                                        | [train_ball_detector.ipynb](notebooks/train_ball_detector.ipynb)                                                                                       |
+| handball court keypoint detection | [Handball Keypoint Detection](https://universe.roboflow.com/handball-wckh8/handball-keypoint-detection-ndvsl)                                      | [train_court_keypoint_detector.ipynb](notebooks/train_court_keypoint_detector.ipynb)                                                                   |
+
+After training, place the exported model weights in:
+
+```text
+examples/handball/data/handball-player-detection.pt
+examples/handball/data/handball-ball-detection.pt
+examples/handball/data/handball-court-keypoint-detection.pt
+```
+
+## modes
+
+- `COURT_RENDERING` - Renders an IHF-standard handball court with the 4 m
+  throw-off area, 6 m goal-area lines, 9 m free-throw lines, 7 m lines,
+  4 m goalkeeper restraining lines, and substitution marks.
+
+  ```bash
+  python main.py --target_dir data --mode COURT_RENDERING
+  ```
+
+- `POINT_RENDERING` - Draws sample player and ball positions on the handball
+  court.
+
+  ```bash
+  python main.py --target_dir data --mode POINT_RENDERING
+  ```
+
+- `PATH_RENDERING` - Draws sample movement paths on the handball court.
+
+  ```bash
+  python main.py --target_dir data --mode PATH_RENDERING
+  ```
+
+- `COURT_DETECTION` - Detects handball court keypoints in a video.
+
+  ```bash
+  python main.py --source_video_path data/input.mp4 \
+  --target_video_path data/court-detection.mp4 \
+  --device cpu --mode COURT_DETECTION
+  ```
+
+- `PLAYER_DETECTION` - Detects players, referees, and goalkeepers in a video.
+
+  ```bash
+  python main.py --source_video_path data/input.mp4 \
+  --target_video_path data/player-detection.mp4 \
+  --device cpu --mode PLAYER_DETECTION
+  ```
+
+- `BALL_DETECTION` - Detects the handball in a video.
+
+  ```bash
+  python main.py --source_video_path data/input.mp4 \
+  --target_video_path data/ball-detection.mp4 \
+  --device cpu --mode BALL_DETECTION
+  ```
+
+- `RADAR` - Combines court keypoints and player detections to draw detected
+  player locations on a rendered handball court.
+
+  ```bash
+  python main.py --source_video_path data/input.mp4 \
+  --target_video_path data/radar.mp4 \
+  --device cpu --mode RADAR
+  ```
+
+- `ALL_RENDERINGS` - Runs all static rendering modes.
+
+  ```bash
+  python main.py --target_dir data --mode ALL_RENDERINGS
+  ```
+
+Static rendering outputs are written to `examples/handball/data`.
+
+## notebooks
+
+| use case                         | notebook                                                        |
+|:---------------------------------|:----------------------------------------------------------------|
+| handball player detection        | [train_player_detector.ipynb](notebooks/train_player_detector.ipynb) |
+| handball ball detection          | [train_ball_detector.ipynb](notebooks/train_ball_detector.ipynb) |
+| handball court keypoint detection | [train_court_keypoint_detector.ipynb](notebooks/train_court_keypoint_detector.ipynb) |
+| handball court render            | [render_court.ipynb](notebooks/render_court.ipynb)              |
+
+## license
+
+This example uses the `sports` package and Supervision-based rendering utilities,
+which are distributed under the MIT license.

--- a/examples/handball/main.py
+++ b/examples/handball/main.py
@@ -1,0 +1,457 @@
+import argparse
+import os
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+import cv2
+import numpy as np
+import supervision as sv
+from ultralytics import YOLO
+
+
+CURRENT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = next(
+    parent for parent in [CURRENT_DIR, *CURRENT_DIR.parents]
+    if (parent / "sports").is_dir()
+)
+sys.path.insert(0, str(REPO_ROOT))
+
+from sports.annotators.handball import (
+    draw_court,
+    draw_paths_on_court,
+    draw_points_on_court,
+)
+from sports.common.view import ViewTransformer
+from sports.configs.handball import HandballCourtConfiguration
+
+
+PARENT_DIR = str(CURRENT_DIR)
+DEFAULT_TARGET_DIR = os.path.join(PARENT_DIR, "data")
+
+PLAYER_DETECTION_MODEL_PATH = os.path.join(
+    PARENT_DIR, "data/handball-player-detection.pt"
+)
+BALL_DETECTION_MODEL_PATH = os.path.join(
+    PARENT_DIR, "data/handball-ball-detection.pt"
+)
+COURT_DETECTION_MODEL_PATH = os.path.join(
+    PARENT_DIR, "data/handball-court-keypoint-detection.pt"
+)
+
+CONFIG = HandballCourtConfiguration()
+TEAM_COLORS = ["#E53935", "#1E88E5", "#FDD835"]
+
+VERTEX_LABEL_ANNOTATOR = sv.VertexLabelAnnotator(
+    color=[sv.Color.from_hex(color) for color in CONFIG.colors],
+    text_color=sv.Color.WHITE,
+    border_radius=5,
+    text_thickness=1,
+    text_scale=0.5,
+    text_padding=5,
+)
+BOX_ANNOTATOR = sv.BoxAnnotator(
+    color=sv.ColorPalette.from_hex(TEAM_COLORS),
+    thickness=2,
+)
+BOX_LABEL_ANNOTATOR = sv.LabelAnnotator(
+    color=sv.ColorPalette.from_hex(TEAM_COLORS),
+    text_color=sv.Color.WHITE,
+    text_padding=5,
+    text_thickness=1,
+)
+BALL_ANNOTATOR = sv.CircleAnnotator(
+    color=sv.Color.from_hex(TEAM_COLORS[2]),
+    thickness=2,
+)
+
+
+class Mode(Enum):
+    """
+    Enum class representing different modes for Handball AI examples.
+    """
+
+    COURT_RENDERING = "COURT_RENDERING"
+    POINT_RENDERING = "POINT_RENDERING"
+    PATH_RENDERING = "PATH_RENDERING"
+    COURT_DETECTION = "COURT_DETECTION"
+    PLAYER_DETECTION = "PLAYER_DETECTION"
+    BALL_DETECTION = "BALL_DETECTION"
+    RADAR = "RADAR"
+    ALL_RENDERINGS = "ALL_RENDERINGS"
+
+
+def ensure_target_dir(target_dir: str) -> None:
+    os.makedirs(target_dir, exist_ok=True)
+
+
+def require_video_paths(
+    source_video_path: Optional[str],
+    target_video_path: Optional[str],
+    mode: Mode,
+) -> Tuple[str, str]:
+    if source_video_path is None or target_video_path is None:
+        raise ValueError(
+            f"{mode.value} requires --source_video_path and --target_video_path."
+        )
+    return source_video_path, target_video_path
+
+
+def labels_from_result(result) -> List[str]:
+    detections = sv.Detections.from_ultralytics(result)
+    names = result.names
+    return [names[class_id] for class_id in detections.class_id]
+
+
+def detection_class_ids(result, class_names: Set[str]) -> List[int]:
+    return [
+        class_id
+        for class_id, class_name in result.names.items()
+        if class_name.lower() in class_names
+    ]
+
+
+def keypoint_correspondences(
+    keypoints: sv.KeyPoints,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    court_vertices = np.array(CONFIG.vertices, dtype=np.float32)
+    detected_xy = keypoints.xy[0].astype(np.float32)
+    point_count = min(len(detected_xy), len(court_vertices))
+
+    source = detected_xy[:point_count]
+    target = court_vertices[:point_count]
+    mask = (source[:, 0] > 1) & (source[:, 1] > 1)
+    return source[mask], target[mask], mask
+
+
+def write_video(
+    source_video_path: str,
+    target_video_path: str,
+    frame_generator: Iterator[np.ndarray],
+) -> None:
+    video_info = sv.VideoInfo.from_video_path(source_video_path)
+    with sv.VideoSink(target_video_path, video_info) as sink:
+        for frame in frame_generator:
+            sink.write_frame(frame)
+
+
+def save_image(target_dir: str, file_name: str, image: np.ndarray) -> str:
+    ensure_target_dir(target_dir)
+    target_path = os.path.join(target_dir, file_name)
+    cv2.imwrite(target_path, image)
+    return target_path
+
+
+def render_court() -> np.ndarray:
+    return draw_court(
+        config=CONFIG,
+        background_color=sv.Color(38, 132, 170),
+        line_color=sv.Color.WHITE,
+        goal_color=sv.Color.RED,
+        padding=80,
+        line_thickness=6,
+        scale=0.2,
+    )
+
+
+def render_points() -> np.ndarray:
+    court = render_court()
+    players = {
+        0: np.array([
+            [650, 750],
+            [1050, 1220],
+            [1500, 530],
+            [2300, 1450],
+            [2850, 760],
+            [3350, 1200],
+        ]),
+        1: np.array([
+            [700, 1240],
+            [1150, 560],
+            [1700, 1460],
+            [2350, 640],
+            [2900, 1300],
+            [3300, 840],
+        ]),
+        2: np.array([[2100, 980]]),
+    }
+
+    for team_id, xy in players.items():
+        court = draw_points_on_court(
+            config=CONFIG,
+            xy=xy,
+            face_color=sv.Color.from_hex(TEAM_COLORS[team_id]),
+            edge_color=sv.Color.WHITE,
+            radius=12,
+            thickness=3,
+            padding=80,
+            scale=0.2,
+            court=court,
+        )
+
+    return court
+
+
+def render_paths() -> np.ndarray:
+    court = render_points()
+    paths = [
+        np.array([[650, 750], [950, 840], [1280, 760], [1600, 900], [2100, 980]]),
+        np.array([[3300, 840], [3020, 900], [2700, 1040], [2400, 980], [2100, 980]]),
+        np.array([[1050, 1220], [1350, 1120], [1680, 1240], [1950, 1100]]),
+    ]
+
+    return draw_paths_on_court(
+        config=CONFIG,
+        paths=paths,
+        color=sv.Color.WHITE,
+        thickness=4,
+        padding=80,
+        scale=0.2,
+        court=court,
+    )
+
+
+def run_court_detection(
+    source_video_path: str,
+    device: str,
+    model_path: str,
+) -> Iterator[np.ndarray]:
+    court_detection_model = YOLO(model_path).to(device=device)
+    frame_generator = sv.get_video_frames_generator(source_path=source_video_path)
+
+    for frame in frame_generator:
+        result = court_detection_model(frame, verbose=False)[0]
+        keypoints = sv.KeyPoints.from_ultralytics(result)
+        label_count = min(len(CONFIG.labels), keypoints.xy.shape[1])
+
+        annotated_frame = frame.copy()
+        annotated_frame = VERTEX_LABEL_ANNOTATOR.annotate(
+            annotated_frame,
+            keypoints,
+            CONFIG.labels[:label_count],
+        )
+        yield annotated_frame
+
+
+def run_player_detection(
+    source_video_path: str,
+    device: str,
+    model_path: str,
+) -> Iterator[np.ndarray]:
+    player_detection_model = YOLO(model_path).to(device=device)
+    frame_generator = sv.get_video_frames_generator(source_path=source_video_path)
+
+    for frame in frame_generator:
+        result = player_detection_model(frame, imgsz=1280, verbose=False)[0]
+        detections = sv.Detections.from_ultralytics(result)
+        labels = labels_from_result(result)
+
+        annotated_frame = frame.copy()
+        annotated_frame = BOX_ANNOTATOR.annotate(annotated_frame, detections)
+        annotated_frame = BOX_LABEL_ANNOTATOR.annotate(
+            annotated_frame, detections, labels=labels
+        )
+        yield annotated_frame
+
+
+def run_ball_detection(
+    source_video_path: str,
+    device: str,
+    model_path: str,
+) -> Iterator[np.ndarray]:
+    ball_detection_model = YOLO(model_path).to(device=device)
+    frame_generator = sv.get_video_frames_generator(source_path=source_video_path)
+
+    for frame in frame_generator:
+        result = ball_detection_model(frame, imgsz=1280, verbose=False)[0]
+        detections = sv.Detections.from_ultralytics(result)
+        labels = labels_from_result(result)
+
+        annotated_frame = frame.copy()
+        annotated_frame = BALL_ANNOTATOR.annotate(annotated_frame, detections)
+        annotated_frame = BOX_LABEL_ANNOTATOR.annotate(
+            annotated_frame, detections, labels=labels
+        )
+        yield annotated_frame
+
+
+def run_radar(
+    source_video_path: str,
+    device: str,
+    player_model_path: str,
+    court_model_path: str,
+) -> Iterator[np.ndarray]:
+    player_detection_model = YOLO(player_model_path).to(device=device)
+    court_detection_model = YOLO(court_model_path).to(device=device)
+    frame_generator = sv.get_video_frames_generator(source_path=source_video_path)
+
+    for frame in frame_generator:
+        court_result = court_detection_model(frame, verbose=False)[0]
+        keypoints = sv.KeyPoints.from_ultralytics(court_result)
+        source, target, _ = keypoint_correspondences(keypoints)
+
+        player_result = player_detection_model(frame, imgsz=1280, verbose=False)[0]
+        detections = sv.Detections.from_ultralytics(player_result)
+        labels = labels_from_result(player_result)
+
+        annotated_frame = frame.copy()
+        annotated_frame = BOX_ANNOTATOR.annotate(annotated_frame, detections)
+        annotated_frame = BOX_LABEL_ANNOTATOR.annotate(
+            annotated_frame, detections, labels=labels
+        )
+
+        if len(source) < 4:
+            yield annotated_frame
+            continue
+
+        player_class_ids = detection_class_ids(
+            player_result, {"player", "goalkeeper"}
+        )
+        player_mask = np.isin(detections.class_id, player_class_ids)
+        players = detections[player_mask]
+        if len(players) == 0:
+            yield annotated_frame
+            continue
+
+        transformer = ViewTransformer(source=source, target=target)
+        xy = players.get_anchors_coordinates(anchor=sv.Position.BOTTOM_CENTER)
+        transformed_xy = transformer.transform_points(points=xy)
+
+        radar = draw_court(config=CONFIG)
+        radar = draw_points_on_court(
+            config=CONFIG,
+            xy=transformed_xy,
+            face_color=sv.Color.from_hex(TEAM_COLORS[0]),
+            edge_color=sv.Color.WHITE,
+            radius=16,
+            court=radar,
+        )
+
+        h, w, _ = frame.shape
+        radar = sv.resize_image(radar, (w // 2, h // 2))
+        radar_h, radar_w, _ = radar.shape
+        rect = sv.Rect(
+            x=w // 2 - radar_w // 2,
+            y=h - radar_h,
+            width=radar_w,
+            height=radar_h,
+        )
+        yield sv.draw_image(annotated_frame, radar, opacity=0.5, rect=rect)
+
+
+def run_rendering_mode(target_dir: str, mode: Mode) -> Dict[str, str]:
+    renderers = {
+        Mode.COURT_RENDERING: ("handball-court.png", render_court),
+        Mode.POINT_RENDERING: ("handball-points.png", render_points),
+        Mode.PATH_RENDERING: ("handball-paths.png", render_paths),
+    }
+
+    if mode == Mode.ALL_RENDERINGS:
+        selected_modes = [
+            Mode.COURT_RENDERING,
+            Mode.POINT_RENDERING,
+            Mode.PATH_RENDERING,
+        ]
+    else:
+        selected_modes = [mode]
+
+    output_paths = {}
+    for selected_mode in selected_modes:
+        file_name, renderer = renderers[selected_mode]
+        output_paths[selected_mode.value] = save_image(
+            target_dir=target_dir,
+            file_name=file_name,
+            image=renderer(),
+        )
+
+    return output_paths
+
+
+def main(
+    source_video_path: Optional[str],
+    target_video_path: Optional[str],
+    target_dir: str,
+    device: str,
+    mode: Mode,
+    player_model_path: str,
+    ball_model_path: str,
+    court_model_path: str,
+) -> Optional[Dict[str, str]]:
+    if mode in {
+        Mode.COURT_RENDERING,
+        Mode.POINT_RENDERING,
+        Mode.PATH_RENDERING,
+        Mode.ALL_RENDERINGS,
+    }:
+        return run_rendering_mode(target_dir=target_dir, mode=mode)
+
+    source_video_path, target_video_path = require_video_paths(
+        source_video_path, target_video_path, mode
+    )
+
+    if mode == Mode.COURT_DETECTION:
+        frame_generator = run_court_detection(
+            source_video_path=source_video_path,
+            device=device,
+            model_path=court_model_path,
+        )
+    elif mode == Mode.PLAYER_DETECTION:
+        frame_generator = run_player_detection(
+            source_video_path=source_video_path,
+            device=device,
+            model_path=player_model_path,
+        )
+    elif mode == Mode.BALL_DETECTION:
+        frame_generator = run_ball_detection(
+            source_video_path=source_video_path,
+            device=device,
+            model_path=ball_model_path,
+        )
+    elif mode == Mode.RADAR:
+        frame_generator = run_radar(
+            source_video_path=source_video_path,
+            device=device,
+            player_model_path=player_model_path,
+            court_model_path=court_model_path,
+        )
+    else:
+        raise NotImplementedError(f"Mode {mode} is not implemented.")
+
+    write_video(
+        source_video_path=source_video_path,
+        target_video_path=target_video_path,
+        frame_generator=frame_generator,
+    )
+    return None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("--source_video_path", type=str)
+    parser.add_argument("--target_video_path", type=str)
+    parser.add_argument("--target_dir", type=str, default=DEFAULT_TARGET_DIR)
+    parser.add_argument("--device", type=str, default="cpu")
+    parser.add_argument("--mode", type=Mode, default=Mode.COURT_RENDERING)
+    parser.add_argument(
+        "--player_model_path", type=str, default=PLAYER_DETECTION_MODEL_PATH
+    )
+    parser.add_argument("--ball_model_path", type=str, default=BALL_DETECTION_MODEL_PATH)
+    parser.add_argument(
+        "--court_model_path", type=str, default=COURT_DETECTION_MODEL_PATH
+    )
+    args = parser.parse_args()
+
+    paths = main(
+        source_video_path=args.source_video_path,
+        target_video_path=args.target_video_path,
+        target_dir=args.target_dir,
+        device=args.device,
+        mode=args.mode,
+        player_model_path=args.player_model_path,
+        ball_model_path=args.ball_model_path,
+        court_model_path=args.court_model_path,
+    )
+    if paths is not None:
+        for mode, target_path in paths.items():
+            print(f"{mode}: {target_path}")

--- a/examples/handball/notebooks/render_court.ipynb
+++ b/examples/handball/notebooks/render_court.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Render a Handball Court\n",
+    "\n",
+    "This notebook demonstrates the handball court configuration and drawing utilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install \"numpy<2\" opencv-python supervision"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "current_dir = Path.cwd().resolve()\n",
+    "repo_root = next(\n",
+    "    parent for parent in [current_dir, *current_dir.parents]\n",
+    "    if (parent / \"sports\").is_dir()\n",
+    ")\n",
+    "sys.path.insert(0, str(repo_root))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import numpy as np\n",
+    "import supervision as sv\n",
+    "\n",
+    "from sports.annotators.handball import draw_court, draw_paths_on_court, draw_points_on_court\n",
+    "from sports.configs.handball import HandballCourtConfiguration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = HandballCourtConfiguration()\n",
+    "court = draw_court(config=config, padding=80, line_thickness=6, scale=0.2)\n",
+    "court.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xy = np.array([\n",
+    "    [650, 750],\n",
+    "    [1050, 1220],\n",
+    "    [2100, 980],\n",
+    "    [3300, 840],\n",
+    "])\n",
+    "\n",
+    "court = draw_points_on_court(\n",
+    "    config=config,\n",
+    "    xy=xy,\n",
+    "    face_color=sv.Color.from_hex(\"#E53935\"),\n",
+    "    edge_color=sv.Color.WHITE,\n",
+    "    radius=12,\n",
+    "    thickness=3,\n",
+    "    padding=80,\n",
+    "    scale=0.2,\n",
+    "    court=court,\n",
+    ")\n",
+    "\n",
+    "paths = [np.array([[650, 750], [950, 840], [1280, 760], [1600, 900], [2100, 980]])]\n",
+    "court = draw_paths_on_court(\n",
+    "    config=config,\n",
+    "    paths=paths,\n",
+    "    color=sv.Color.WHITE,\n",
+    "    thickness=4,\n",
+    "    padding=80,\n",
+    "    scale=0.2,\n",
+    "    court=court,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cv2.imwrite(\"handball-court.png\", court)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/handball/notebooks/train_ball_detector.ipynb
+++ b/examples/handball/notebooks/train_ball_detector.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a Handball Ball Detector\n",
+    "\n",
+    "This notebook downloads one of the Roboflow Universe handball ball datasets and trains a YOLO detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install \"numpy<2\" opencv-python roboflow supervision ultralytics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the next training cell fails with `RuntimeError: Numpy is not available`, restart the notebook runtime after running the install cell, then run the notebook from the top. PyTorch must be imported after the pinned NumPy version is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from roboflow import Roboflow\n",
+    "\n",
+    "BALL_DATASETS = {\n",
+    "    \"handball_ballon\": {\n",
+    "        \"workspace\": \"handballdetection\",\n",
+    "        \"project\": \"handball-ballon\",\n",
+    "        \"version\": 7,\n",
+    "        \"directory\": \"handball-ballon\",\n",
+    "    },\n",
+    "    \"ball_only_detection\": {\n",
+    "        \"workspace\": \"handball-detection\",\n",
+    "        \"project\": \"ball-only-detection\",\n",
+    "        \"version\": 1,\n",
+    "        \"directory\": \"ball-only-detection\",\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "SELECTED_DATASET = \"handball_ballon\"\n",
+    "EXAMPLE_DIR = Path.cwd().resolve().parent\n",
+    "RUNS_DIR = EXAMPLE_DIR / \"data\" / \"runs\"\n",
+    "ROBOFLOW_API_KEY = os.environ.get(\"ROBOFLOW_API_KEY\", \"YOUR_API_KEY\")\n",
+    "\n",
+    "dataset_config = BALL_DATASETS[SELECTED_DATASET]\n",
+    "DATASET_DIR = EXAMPLE_DIR / \"data\" / \"datasets\" / dataset_config[\"directory\"]\n",
+    "rf = Roboflow(api_key=ROBOFLOW_API_KEY)\n",
+    "project = rf.workspace(dataset_config[\"workspace\"]).project(dataset_config[\"project\"])\n",
+    "dataset = project.version(dataset_config[\"version\"]).download(\"yolov8\", location=str(DATASET_DIR))\n",
+    "dataset.location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!yolo task=detect mode=train model=yolov8n.pt data={dataset.location}/data.yaml epochs=100 imgsz=640 project={RUNS_DIR} name=handball-ball-detection"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/handball/notebooks/train_court_keypoint_detector.ipynb
+++ b/examples/handball/notebooks/train_court_keypoint_detector.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a Handball Court Keypoint Detector\n",
+    "\n",
+    "This notebook downloads the Roboflow Universe handball court keypoint dataset and trains a YOLO pose model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install \"numpy<2\" opencv-python roboflow supervision ultralytics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the next training cell fails with `RuntimeError: Numpy is not available`, restart the notebook runtime after running the install cell, then run the notebook from the top. PyTorch must be imported after the pinned NumPy version is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from roboflow import Roboflow\n",
+    "\n",
+    "EXAMPLE_DIR = Path.cwd().resolve().parent\n",
+    "DATASET_DIR = EXAMPLE_DIR / \"data\" / \"datasets\" / \"handball-court-keypoints\"\n",
+    "RUNS_DIR = EXAMPLE_DIR / \"data\" / \"runs\"\n",
+    "\n",
+    "ROBOFLOW_API_KEY = os.environ.get(\"ROBOFLOW_API_KEY\", \"YOUR_API_KEY\")\n",
+    "rf = Roboflow(api_key=ROBOFLOW_API_KEY)\n",
+    "\n",
+    "project = rf.workspace(\"handball-wckh8\").project(\"handball-keypoint-detection-ndvsl\")\n",
+    "dataset = project.version(7).download(\"yolov8\", location=str(DATASET_DIR))\n",
+    "dataset.location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!yolo task=pose mode=train model=yolov8n-pose.pt data={dataset.location}/data.yaml epochs=100 imgsz=640 project={RUNS_DIR} name=handball-court-keypoints"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/handball/notebooks/train_player_detector.ipynb
+++ b/examples/handball/notebooks/train_player_detector.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train a Handball Player Detector\n",
+    "\n",
+    "This notebook downloads the Roboflow Universe handball player dataset and trains a YOLO detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c9af28e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install \"numpy<2\" opencv-python roboflow supervision ultralytics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7e4f3a2",
+   "metadata": {},
+   "source": [
+    "If the next training cell fails with `RuntimeError: Numpy is not available`, restart the notebook runtime after running the install cell, then run the notebook from the top. PyTorch must be imported after the pinned NumPy version is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9772462",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from roboflow import Roboflow\n",
+    "\n",
+    "EXAMPLE_DIR = Path.cwd().resolve().parent\n",
+    "DATASET_DIR = EXAMPLE_DIR / \"data\" / \"datasets\" / \"handball-player-detection\"\n",
+    "RUNS_DIR = EXAMPLE_DIR / \"data\" / \"runs\"\n",
+    "\n",
+    "ROBOFLOW_API_KEY = os.environ.get(\"ROBOFLOW_API_KEY\", \"YOUR_API_KEY\")\n",
+    "rf = Roboflow(api_key=ROBOFLOW_API_KEY)\n",
+    "\n",
+    "project = rf.workspace(\"project-k1mun\").project(\"handball_player_detection\")\n",
+    "dataset = project.version(2).download(\"yolov8\", location=str(DATASET_DIR))\n",
+    "dataset.location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!yolo task=detect mode=train model=yolov8n.pt data={dataset.location}/data.yaml epochs=100 imgsz=640 project={RUNS_DIR} name=handball-player-detection"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/handball/requirements.txt
+++ b/examples/handball/requirements.txt
@@ -1,0 +1,5 @@
+numpy<2
+opencv-python
+roboflow
+supervision
+ultralytics

--- a/examples/handball/setup.sh
+++ b/examples/handball/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Check if 'data' directory does not exist and then create it
+if [[ ! -e $DIR/data ]]; then
+    mkdir "$DIR/data"
+else
+    echo "'data' directory already exists."
+fi
+
+cat << EOF
+
+Place trained model weights in:
+  $DIR/data/handball-player-detection.pt
+  $DIR/data/handball-ball-detection.pt
+  $DIR/data/handball-court-keypoint-detection.pt
+
+Use the notebooks in $DIR/notebooks to train models from the Roboflow Universe
+datasets referenced in README.md.
+EOF

--- a/sports/annotators/handball.py
+++ b/sports/annotators/handball.py
@@ -1,0 +1,11 @@
+from sports.handball.annotators import (
+    draw_court,
+    draw_paths_on_court,
+    draw_points_on_court,
+)
+
+__all__ = [
+    "draw_court",
+    "draw_paths_on_court",
+    "draw_points_on_court",
+]

--- a/sports/configs/__init__.py
+++ b/sports/configs/__init__.py
@@ -1,0 +1,7 @@
+from sports.configs.handball import HandballCourtConfiguration
+from sports.configs.soccer import SoccerPitchConfiguration
+
+__all__ = [
+    "HandballCourtConfiguration",
+    "SoccerPitchConfiguration",
+]

--- a/sports/configs/handball.py
+++ b/sports/configs/handball.py
@@ -1,0 +1,3 @@
+from sports.handball.config import CourtConfiguration, HandballCourtConfiguration
+
+__all__ = ["CourtConfiguration", "HandballCourtConfiguration"]

--- a/sports/handball/__init__.py
+++ b/sports/handball/__init__.py
@@ -1,0 +1,17 @@
+from sports.handball.config import CourtConfiguration, HandballCourtConfiguration
+
+__all__ = [
+    "CourtConfiguration",
+    "HandballCourtConfiguration",
+    "draw_court",
+    "draw_paths_on_court",
+    "draw_points_on_court",
+]
+
+
+def __getattr__(name):
+    if name in {"draw_court", "draw_paths_on_court", "draw_points_on_court"}:
+        from sports.handball import annotators
+
+        return getattr(annotators, name)
+    raise AttributeError(f"module 'sports.handball' has no attribute {name!r}")

--- a/sports/handball/annotators.py
+++ b/sports/handball/annotators.py
@@ -1,0 +1,520 @@
+from math import asin, degrees
+from typing import List, Optional, Tuple
+
+import cv2
+import numpy as np
+import supervision as sv
+
+from sports.handball.config import HandballCourtConfiguration
+
+
+def _to_pixel(
+    point: Tuple[float, float],
+    scale: float,
+    padding: int,
+) -> Tuple[int, int]:
+    return (
+        int(round(point[0] * scale + padding)),
+        int(round(point[1] * scale + padding)),
+    )
+
+
+def _arc_point(
+    center: Tuple[float, float],
+    radius: float,
+    angle_degrees: float,
+) -> Tuple[float, float]:
+    angle = np.deg2rad(angle_degrees)
+    return (
+        center[0] + radius * np.cos(angle),
+        center[1] + radius * np.sin(angle),
+    )
+
+
+def _draw_arc(
+    image: np.ndarray,
+    center: Tuple[float, float],
+    radius: float,
+    start_degrees: float,
+    end_degrees: float,
+    color: Tuple[int, int, int],
+    thickness: int,
+    scale: float,
+    padding: int,
+) -> None:
+    center_px = _to_pixel(center, scale, padding)
+    radius_px = int(round(radius * scale))
+    cv2.ellipse(
+        img=image,
+        center=center_px,
+        axes=(radius_px, radius_px),
+        angle=0,
+        startAngle=int(round(start_degrees)),
+        endAngle=int(round(end_degrees)),
+        color=color,
+        thickness=thickness,
+    )
+
+
+def _draw_dashed_line(
+    image: np.ndarray,
+    start: Tuple[int, int],
+    end: Tuple[int, int],
+    color: Tuple[int, int, int],
+    thickness: int,
+    dash_length: float,
+    gap_length: float,
+) -> None:
+    start_np = np.array(start, dtype=float)
+    end_np = np.array(end, dtype=float)
+    delta = end_np - start_np
+    length = float(np.linalg.norm(delta))
+    if length == 0:
+        return
+
+    direction = delta / length
+    distance = 0.0
+    while distance < length:
+        dash_start = start_np + direction * distance
+        dash_end = start_np + direction * min(distance + dash_length, length)
+        cv2.line(
+            image,
+            tuple(np.round(dash_start).astype(int)),
+            tuple(np.round(dash_end).astype(int)),
+            color,
+            thickness,
+        )
+        distance += dash_length + gap_length
+
+
+def _draw_dashed_arc(
+    image: np.ndarray,
+    center: Tuple[float, float],
+    radius: float,
+    start_degrees: float,
+    end_degrees: float,
+    color: Tuple[int, int, int],
+    thickness: int,
+    scale: float,
+    padding: int,
+    dash_length: float,
+    gap_length: float,
+    detail_degrees: float = 1,
+) -> None:
+    dash_length_degrees = degrees(dash_length / radius)
+    gap_length_degrees = degrees(gap_length / radius)
+    angle = start_degrees
+    while angle < end_degrees:
+        dash_end = min(angle + dash_length_degrees, end_degrees)
+        samples = np.arange(angle, dash_end + detail_degrees, detail_degrees)
+        points = np.array(
+            [
+                _to_pixel(_arc_point(center, radius, sample), scale, padding)
+                for sample in samples
+            ],
+            dtype=np.int32,
+        )
+        if len(points) >= 2:
+            cv2.polylines(
+                image,
+                [points],
+                isClosed=False,
+                color=color,
+                thickness=thickness,
+                lineType=cv2.LINE_AA,
+            )
+        angle = dash_end + gap_length_degrees
+
+
+def _draw_goal_frame(
+    image: np.ndarray,
+    config: HandballCourtConfiguration,
+    side: str,
+    color: Tuple[int, int, int],
+    thickness: int,
+    scale: float,
+    padding: int,
+) -> None:
+    if side == "left":
+        points = [
+            (-config.goal_depth, config.goal_top_y),
+            (0, config.goal_top_y),
+            (-config.goal_depth, config.goal_top_y),
+            (-config.goal_depth, config.goal_bottom_y),
+            (-config.goal_depth, config.goal_bottom_y),
+            (0, config.goal_bottom_y),
+        ]
+    else:
+        points = [
+            (config.length, config.goal_top_y),
+            (config.length + config.goal_depth, config.goal_top_y),
+            (config.length + config.goal_depth, config.goal_top_y),
+            (config.length + config.goal_depth, config.goal_bottom_y),
+            (config.length + config.goal_depth, config.goal_bottom_y),
+            (config.length, config.goal_bottom_y),
+        ]
+
+    for i in range(0, len(points), 2):
+        cv2.line(
+            image,
+            _to_pixel(points[i], scale, padding),
+            _to_pixel(points[i + 1], scale, padding),
+            color,
+            thickness,
+        )
+
+
+def _draw_substitution_marks(
+    image: np.ndarray,
+    config: HandballCourtConfiguration,
+    color: Tuple[int, int, int],
+    thickness: int,
+    scale: float,
+    padding: int,
+) -> None:
+    mark_half_length = config.substitution_line_length / 2
+    for x in (
+        config.center_x - config.substitution_line_distance,
+        config.center_x + config.substitution_line_distance,
+    ):
+        top_start = _to_pixel((x, -mark_half_length), scale, padding)
+        top_end = _to_pixel((x, mark_half_length), scale, padding)
+        bottom_start = _to_pixel((x, config.width - mark_half_length), scale, padding)
+        bottom_end = _to_pixel((x, config.width + mark_half_length), scale, padding)
+        cv2.line(image, top_start, top_end, color, thickness)
+        cv2.line(image, bottom_start, bottom_end, color, thickness)
+
+
+def draw_court(
+    config: HandballCourtConfiguration,
+    background_color: sv.Color = sv.Color(38, 132, 170),
+    line_color: sv.Color = sv.Color.WHITE,
+    goal_color: sv.Color = sv.Color.RED,
+    throw_off_area_color: Optional[sv.Color] = None,
+    padding: int = 50,
+    line_thickness: int = 4,
+    scale: float = 0.1,
+) -> np.ndarray:
+    """
+    Draws a handball court with IHF-standard markings.
+
+    Args:
+        config (HandballCourtConfiguration): Configuration object containing the
+            dimensions and layout of the court.
+        background_color (sv.Color, optional): Color of the court background.
+            Defaults to sv.Color(38, 132, 170).
+        line_color (sv.Color, optional): Color of the court lines.
+            Defaults to sv.Color.WHITE.
+        goal_color (sv.Color, optional): Color of the goal frame.
+            Defaults to sv.Color.RED.
+        throw_off_area_color (Optional[sv.Color], optional): Fill color for
+            the throw-off area. If None, only the circle line is drawn.
+        padding (int, optional): Padding around the court in pixels.
+            Defaults to 50.
+        line_thickness (int, optional): Thickness of the court lines in pixels.
+            Defaults to 4.
+        scale (float, optional): Scaling factor for the court dimensions.
+            Defaults to 0.1.
+
+    Returns:
+        np.ndarray: Image of the handball court.
+    """
+    scaled_width = int(round(config.width * scale))
+    scaled_length = int(round(config.length * scale))
+    court = np.ones(
+        (scaled_width + 2 * padding, scaled_length + 2 * padding, 3),
+        dtype=np.uint8,
+    ) * np.array(background_color.as_bgr(), dtype=np.uint8)
+
+    bgr_line = line_color.as_bgr()
+    bgr_goal = goal_color.as_bgr()
+    center = (config.center_x, config.center_y)
+
+    if throw_off_area_color is not None:
+        cv2.circle(
+            court,
+            _to_pixel(center, scale, padding),
+            radius=int(round(config.throw_off_area_radius * scale)),
+            color=throw_off_area_color.as_bgr(),
+            thickness=-1,
+        )
+
+    for start, end in config.edges:
+        point1 = _to_pixel(config.vertices[start - 1], scale, padding)
+        point2 = _to_pixel(config.vertices[end - 1], scale, padding)
+        cv2.line(court, point1, point2, bgr_line, line_thickness)
+
+    _draw_goal_frame(
+        court, config, "left", bgr_goal, line_thickness, scale, padding
+    )
+    _draw_goal_frame(
+        court, config, "right", bgr_goal, line_thickness, scale, padding
+    )
+
+    left_top_goal_center = (0, config.goal_top_y)
+    left_bottom_goal_center = (0, config.goal_bottom_y)
+    right_top_goal_center = (config.length, config.goal_top_y)
+    right_bottom_goal_center = (config.length, config.goal_bottom_y)
+
+    _draw_arc(
+        court,
+        left_top_goal_center,
+        config.goal_area_radius,
+        270,
+        360,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+    )
+    _draw_arc(
+        court,
+        left_bottom_goal_center,
+        config.goal_area_radius,
+        0,
+        90,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+    )
+    _draw_arc(
+        court,
+        right_top_goal_center,
+        config.goal_area_radius,
+        180,
+        270,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+    )
+    _draw_arc(
+        court,
+        right_bottom_goal_center,
+        config.goal_area_radius,
+        90,
+        180,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+    )
+
+    sideline_angle = degrees(asin(config.goal_top_y / config.free_throw_radius))
+    dash_length_px = max(1, config.free_throw_line_segment_length * scale)
+    gap_length_px = max(1, config.free_throw_line_gap_length * scale)
+    arc_dash_kwargs = {
+        "dash_length": config.free_throw_line_segment_length,
+        "gap_length": config.free_throw_line_gap_length,
+    }
+
+    _draw_dashed_arc(
+        court,
+        left_top_goal_center,
+        config.free_throw_radius,
+        360 - sideline_angle,
+        360,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+        **arc_dash_kwargs,
+    )
+    _draw_dashed_line(
+        court,
+        _to_pixel((config.free_throw_radius, config.goal_top_y), scale, padding),
+        _to_pixel((config.free_throw_radius, config.goal_bottom_y), scale, padding),
+        bgr_line,
+        line_thickness,
+        dash_length_px,
+        gap_length_px,
+    )
+    _draw_dashed_arc(
+        court,
+        left_bottom_goal_center,
+        config.free_throw_radius,
+        0,
+        sideline_angle,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+        **arc_dash_kwargs,
+    )
+    _draw_dashed_arc(
+        court,
+        right_top_goal_center,
+        config.free_throw_radius,
+        180,
+        180 + sideline_angle,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+        **arc_dash_kwargs,
+    )
+    _draw_dashed_line(
+        court,
+        _to_pixel(
+            (config.length - config.free_throw_radius, config.goal_top_y),
+            scale,
+            padding,
+        ),
+        _to_pixel(
+            (config.length - config.free_throw_radius, config.goal_bottom_y),
+            scale,
+            padding,
+        ),
+        bgr_line,
+        line_thickness,
+        dash_length_px,
+        gap_length_px,
+    )
+    _draw_dashed_arc(
+        court,
+        right_bottom_goal_center,
+        config.free_throw_radius,
+        180 - sideline_angle,
+        180,
+        bgr_line,
+        line_thickness,
+        scale,
+        padding,
+        **arc_dash_kwargs,
+    )
+
+    _draw_substitution_marks(
+        court, config, bgr_line, line_thickness, scale, padding
+    )
+
+    cv2.circle(
+        court,
+        _to_pixel(center, scale, padding),
+        radius=int(round(config.throw_off_area_radius * scale)),
+        color=bgr_line,
+        thickness=line_thickness,
+    )
+
+    return court
+
+
+def draw_points_on_court(
+    config: HandballCourtConfiguration,
+    xy: np.ndarray,
+    face_color: sv.Color = sv.Color.RED,
+    edge_color: sv.Color = sv.Color.BLACK,
+    radius: int = 10,
+    thickness: int = 2,
+    padding: int = 50,
+    scale: float = 0.1,
+    court: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """
+    Draws points on a handball court.
+
+    Args:
+        config (HandballCourtConfiguration): Configuration object containing the
+            dimensions and layout of the court.
+        xy (np.ndarray): Array of points to draw as (x, y) coordinates.
+        face_color (sv.Color, optional): Color of the point faces.
+            Defaults to sv.Color.RED.
+        edge_color (sv.Color, optional): Color of the point edges.
+            Defaults to sv.Color.BLACK.
+        radius (int, optional): Radius of the points in pixels.
+            Defaults to 10.
+        thickness (int, optional): Thickness of the point edges in pixels.
+            Defaults to 2.
+        padding (int, optional): Padding around the court in pixels.
+            Defaults to 50.
+        scale (float, optional): Scaling factor for court coordinates.
+            Defaults to 0.1.
+        court (Optional[np.ndarray], optional): Existing court image to draw on.
+
+    Returns:
+        np.ndarray: Image of the handball court with points drawn on it.
+    """
+    if court is None:
+        court = draw_court(config=config, padding=padding, scale=scale)
+
+    if xy is None or np.size(xy) == 0:
+        return court
+
+    for point in np.atleast_2d(xy):
+        scaled_point = _to_pixel(tuple(point), scale, padding)
+        cv2.circle(
+            img=court,
+            center=scaled_point,
+            radius=radius,
+            color=face_color.as_bgr(),
+            thickness=-1,
+        )
+        cv2.circle(
+            img=court,
+            center=scaled_point,
+            radius=radius,
+            color=edge_color.as_bgr(),
+            thickness=thickness,
+        )
+
+    return court
+
+
+def draw_paths_on_court(
+    config: HandballCourtConfiguration,
+    paths: List[np.ndarray],
+    color: sv.Color = sv.Color.WHITE,
+    thickness: int = 2,
+    padding: int = 50,
+    scale: float = 0.1,
+    court: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """
+    Draws paths on a handball court.
+
+    Args:
+        config (HandballCourtConfiguration): Configuration object containing the
+            dimensions and layout of the court.
+        paths (List[np.ndarray]): List of paths with (x, y) coordinates.
+        color (sv.Color, optional): Color of the paths.
+            Defaults to sv.Color.WHITE.
+        thickness (int, optional): Thickness of the paths in pixels.
+            Defaults to 2.
+        padding (int, optional): Padding around the court in pixels.
+            Defaults to 50.
+        scale (float, optional): Scaling factor for court coordinates.
+            Defaults to 0.1.
+        court (Optional[np.ndarray], optional): Existing court image to draw on.
+
+    Returns:
+        np.ndarray: Image of the handball court with paths drawn on it.
+    """
+    if court is None:
+        court = draw_court(config=config, padding=padding, scale=scale)
+
+    if not paths:
+        return court
+
+    for path in paths:
+        if path is None or np.size(path) == 0:
+            continue
+
+        scaled_path = [
+            _to_pixel(tuple(point), scale, padding)
+            for point in np.atleast_2d(path)
+            if point.size > 0 and not np.isnan(point).any()
+        ]
+
+        if len(scaled_path) < 2:
+            continue
+
+        for i in range(len(scaled_path) - 1):
+            cv2.line(
+                img=court,
+                pt1=scaled_path[i],
+                pt2=scaled_path[i + 1],
+                color=color.as_bgr(),
+                thickness=thickness,
+            )
+
+    return court

--- a/sports/handball/config.py
+++ b/sports/handball/config.py
@@ -1,0 +1,164 @@
+from dataclasses import dataclass, field
+from math import sqrt
+from typing import List, Tuple
+
+
+@dataclass
+class HandballCourtConfiguration:
+    length: int = 4000  # [cm]
+    width: int = 2000  # [cm]
+    goal_width: int = 300  # [cm]
+    goal_depth: int = 100  # [cm]
+    goal_area_radius: int = 600  # [cm]
+    free_throw_radius: int = 900  # [cm]
+    seven_meter_line_distance: int = 700  # [cm]
+    seven_meter_line_length: int = 100  # [cm]
+    goalkeeper_restraining_line_distance: int = 400  # [cm]
+    goalkeeper_restraining_line_length: int = 15  # [cm]
+    throw_off_area_radius: int = 200  # [cm]
+    free_throw_line_segment_length: int = 15  # [cm]
+    free_throw_line_gap_length: int = 15  # [cm]
+    substitution_line_distance: int = 450  # [cm]
+    substitution_line_length: int = 30  # [cm]
+
+    @property
+    def goal_top_y(self) -> float:
+        return (self.width - self.goal_width) / 2
+
+    @property
+    def goal_bottom_y(self) -> float:
+        return (self.width + self.goal_width) / 2
+
+    @property
+    def center_y(self) -> float:
+        return self.width / 2
+
+    @property
+    def center_x(self) -> float:
+        return self.length / 2
+
+    @property
+    def free_throw_sideline_x_offset(self) -> float:
+        vertical_distance = self.goal_top_y
+        return sqrt(self.free_throw_radius ** 2 - vertical_distance ** 2)
+
+    @property
+    def vertices(self) -> List[Tuple[float, float]]:
+        seven_meter_half_length = self.seven_meter_line_length / 2
+        goalkeeper_line_half_length = self.goalkeeper_restraining_line_length / 2
+        free_throw_x = self.free_throw_sideline_x_offset
+
+        return [
+            (0, 0),  # 1
+            (self.center_x, 0),  # 2
+            (self.length, 0),  # 3
+            (self.length, self.width),  # 4
+            (self.center_x, self.width),  # 5
+            (0, self.width),  # 6
+            (0, self.goal_top_y),  # 7
+            (0, self.goal_bottom_y),  # 8
+            (self.length, self.goal_top_y),  # 9
+            (self.length, self.goal_bottom_y),  # 10
+            (0, self.goal_top_y - self.goal_area_radius),  # 11
+            (self.goal_area_radius, self.goal_top_y),  # 12
+            (self.goal_area_radius, self.goal_bottom_y),  # 13
+            (0, self.goal_bottom_y + self.goal_area_radius),  # 14
+            (self.length, self.goal_top_y - self.goal_area_radius),  # 15
+            (self.length - self.goal_area_radius, self.goal_top_y),  # 16
+            (self.length - self.goal_area_radius, self.goal_bottom_y),  # 17
+            (self.length, self.goal_bottom_y + self.goal_area_radius),  # 18
+            (free_throw_x, 0),  # 19
+            (self.free_throw_radius, self.goal_top_y),  # 20
+            (self.free_throw_radius, self.goal_bottom_y),  # 21
+            (free_throw_x, self.width),  # 22
+            (self.length - free_throw_x, 0),  # 23
+            (self.length - self.free_throw_radius, self.goal_top_y),  # 24
+            (self.length - self.free_throw_radius, self.goal_bottom_y),  # 25
+            (self.length - free_throw_x, self.width),  # 26
+            (
+                self.seven_meter_line_distance,
+                self.center_y - seven_meter_half_length,
+            ),  # 27
+            (
+                self.seven_meter_line_distance,
+                self.center_y + seven_meter_half_length,
+            ),  # 28
+            (
+                self.length - self.seven_meter_line_distance,
+                self.center_y - seven_meter_half_length,
+            ),  # 29
+            (
+                self.length - self.seven_meter_line_distance,
+                self.center_y + seven_meter_half_length,
+            ),  # 30
+            (
+                self.goalkeeper_restraining_line_distance,
+                self.center_y - goalkeeper_line_half_length,
+            ),  # 31
+            (
+                self.goalkeeper_restraining_line_distance,
+                self.center_y + goalkeeper_line_half_length,
+            ),  # 32
+            (
+                self.length - self.goalkeeper_restraining_line_distance,
+                self.center_y - goalkeeper_line_half_length,
+            ),  # 33
+            (
+                self.length - self.goalkeeper_restraining_line_distance,
+                self.center_y + goalkeeper_line_half_length,
+            ),  # 34
+            (self.center_x, self.center_y),  # 35
+            (self.center_x - self.substitution_line_distance, 0),  # 36
+            (self.center_x + self.substitution_line_distance, 0),  # 37
+            (self.center_x - self.substitution_line_distance, self.width),  # 38
+            (self.center_x + self.substitution_line_distance, self.width),  # 39
+        ]
+
+    edges: List[Tuple[int, int]] = field(default_factory=lambda: [
+        (1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 1),
+        (2, 5),
+        (12, 13), (16, 17),
+        (27, 28), (29, 30),
+        (31, 32), (33, 34),
+    ])
+
+    labels: List[str] = field(default_factory=lambda: [
+        "01", "02", "03", "04", "05", "06", "07", "08", "09", "10",
+        "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+        "21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
+        "31", "32", "33", "34", "35", "36", "37", "38", "39",
+    ])
+
+    colors: List[str] = field(default_factory=lambda: [
+        "#FF1493", "#00BFFF", "#FF1493", "#FF1493", "#00BFFF",
+        "#FF1493", "#A4F84B", "#A4F84B", "#A4F84B", "#A4F84B",
+        "#FF6347", "#FF6347", "#FF6347", "#FF6347", "#FF6347",
+        "#FF6347", "#FF6347", "#FF6347", "#FFD700", "#FFD700",
+        "#FFD700", "#FFD700", "#FFD700", "#FFD700", "#FFD700",
+        "#FFD700", "#52F8C4", "#52F8C4", "#52F8C4", "#52F8C4",
+        "#A849F1", "#A849F1", "#A849F1", "#A849F1", "#00BFFF",
+        "#FFFFFF", "#FFFFFF", "#FFFFFF", "#FFFFFF",
+    ])
+
+    @property
+    def court_corner_indexes(self) -> List[int]:
+        return [1, 3, 4, 6]
+
+    @property
+    def left_goal_indexes(self) -> List[int]:
+        return [7, 8]
+
+    @property
+    def right_goal_indexes(self) -> List[int]:
+        return [9, 10]
+
+    @property
+    def left_goal_area_indexes(self) -> List[int]:
+        return [11, 12, 13, 14]
+
+    @property
+    def right_goal_area_indexes(self) -> List[int]:
+        return [15, 16, 17, 18]
+
+
+CourtConfiguration = HandballCourtConfiguration

--- a/tests/test_handball_config.py
+++ b/tests/test_handball_config.py
@@ -1,0 +1,51 @@
+import unittest
+
+from sports.handball.config import CourtConfiguration, HandballCourtConfiguration
+
+
+class HandballCourtConfigurationTest(unittest.TestCase):
+    def test_default_court_dimensions(self):
+        config = HandballCourtConfiguration()
+
+        self.assertEqual(config.length, 4000)
+        self.assertEqual(config.width, 2000)
+        self.assertEqual(config.goal_width, 300)
+        self.assertEqual(config.throw_off_area_radius, 200)
+        self.assertEqual(config.free_throw_line_segment_length, 15)
+        self.assertEqual(config.free_throw_line_gap_length, 15)
+
+    def test_vertices_and_metadata_have_matching_lengths(self):
+        config = CourtConfiguration()
+
+        self.assertEqual(len(config.vertices), 39)
+        self.assertEqual(len(config.labels), len(config.vertices))
+        self.assertEqual(len(config.colors), len(config.vertices))
+
+    def test_key_indexes_use_existing_vertices(self):
+        config = CourtConfiguration()
+        vertex_count = len(config.vertices)
+
+        for indexes in [
+            config.court_corner_indexes,
+            config.left_goal_indexes,
+            config.right_goal_indexes,
+            config.left_goal_area_indexes,
+            config.right_goal_area_indexes,
+        ]:
+            self.assertTrue(all(1 <= index <= vertex_count for index in indexes))
+
+    def test_free_throw_line_intersects_sideline(self):
+        config = CourtConfiguration()
+        left_top_free_throw_vertex = config.vertices[18]
+        right_top_free_throw_vertex = config.vertices[22]
+
+        self.assertEqual(left_top_free_throw_vertex[1], 0)
+        self.assertEqual(right_top_free_throw_vertex[1], 0)
+        self.assertAlmostEqual(
+            left_top_free_throw_vertex[0],
+            config.length - right_top_free_throw_vertex[0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add an IHF-standard handball court configuration with court dimensions, key vertices, labels, colors, and compatibility exports.
- Add handball court rendering utilities for drawing the court, points, and paths.
- Include the 4 m diameter throw-off area and rulebook-aligned free-throw and substitution markings.
- Add focused tests for the handball configuration geometry and metadata.
- Add `examples/handball` with a runnable example script, static court rendering notebook, setup files, and ignored output directories.
- Add Roboflow Universe dataset references and training notebooks for handball player, ball, and court keypoint models.

## Roboflow datasets

- Player detection: https://universe.roboflow.com/project-k1mun/handball_player_detection
- Ball detection: https://universe.roboflow.com/handballdetection/handball-ballon
- Ball detection: https://universe.roboflow.com/handball-detection/ball-only-detection
- Court keypoint detection: https://universe.roboflow.com/handball-wckh8/handball-keypoint-detection-ndvsl

## Notes

- Training notebooks use `numpy<2` to avoid PyTorch/NumPy ABI issues in notebook runtimes.
- Training notebooks use `yolov8` exports because the handball keypoint dataset does not support `yolov11` export.

## Validation

- `python3 -m unittest discover tests`
- `python3 -m compileall examples/handball sports tests`
- Notebook JSON parse for all `examples/handball/notebooks/*.ipynb` files