### PR TITLE
feat/shared foundation for analytics (PR 1)

### DIFF
--- a/examples/soccer/main.py
+++ b/examples/soccer/main.py
@@ -13,17 +13,18 @@ from sports.annotators.soccer import draw_pitch, draw_points_on_pitch
 from sports.common.ball import BallTracker, BallAnnotator
 from sports.common.team import TeamClassifier
 from sports.common.view import ViewTransformer
-from sports.configs.soccer import SoccerPitchConfiguration
+from sports.configs.soccer import (
+    BALL_CLASS_ID,
+    GOALKEEPER_CLASS_ID,
+    PLAYER_CLASS_ID,
+    REFEREE_CLASS_ID,
+    SoccerPitchConfiguration,
+)
 
 PARENT_DIR = os.path.dirname(os.path.abspath(__file__))
 PLAYER_DETECTION_MODEL_PATH = os.path.join(PARENT_DIR, 'data/football-player-detection.pt')
 PITCH_DETECTION_MODEL_PATH = os.path.join(PARENT_DIR, 'data/football-pitch-detection.pt')
 BALL_DETECTION_MODEL_PATH = os.path.join(PARENT_DIR, 'data/football-ball-detection.pt')
-
-BALL_CLASS_ID = 0
-GOALKEEPER_CLASS_ID = 1
-PLAYER_CLASS_ID = 2
-REFEREE_CLASS_ID = 3
 
 STRIDE = 60
 CONFIG = SoccerPitchConfiguration()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text(encoding="utf-8")
 setuptools.setup(
     name="sports",
     version='0.1.0',
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     description="",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/sports/common/draw.py
+++ b/sports/common/draw.py
@@ -1,0 +1,39 @@
+import cv2
+import numpy as np
+
+
+def draw_text_shadow(
+    frame: np.ndarray,
+    text: str,
+    org: tuple,
+    font_scale: float = 0.7,
+    color_bgr: tuple = (255, 255, 255),
+    thickness: int = 2,
+    shadow_offset: tuple = (2, 2),
+    font=cv2.FONT_HERSHEY_SIMPLEX,
+) -> None:
+    """
+    Draw text with a dark shadow for readability on video frames.
+
+    Args:
+        frame (np.ndarray): BGR image to draw on (modified in place).
+        text (str): Label text (ASCII).
+        org (tuple): Bottom-left origin (x, y) for the foreground text.
+        font_scale (float): OpenCV font scale.
+        color_bgr (tuple): Foreground text color in BGR.
+        thickness (int): Foreground stroke thickness.
+        shadow_offset (tuple): Shadow displacement (dx, dy) from the origin.
+        font: OpenCV font identifier.
+    """
+    x, y = org
+    sx, sy = shadow_offset
+    shadow_thickness = thickness + 1 if font == cv2.FONT_HERSHEY_SIMPLEX else thickness
+    shadow_color = (12, 12, 12) if font == cv2.FONT_HERSHEY_SIMPLEX else (0, 0, 0)
+    cv2.putText(
+        frame, text, (x + sx, y + sy), font, font_scale,
+        shadow_color, shadow_thickness, cv2.LINE_AA,
+    )
+    cv2.putText(
+        frame, text, (x, y), font, font_scale,
+        color_bgr, thickness, cv2.LINE_AA,
+    )

--- a/sports/common/homography.py
+++ b/sports/common/homography.py
@@ -37,6 +37,14 @@ class RansacViewTransformer(ViewTransformer):
         if src.shape != dst.shape or src.ndim != 2 or src.shape[1] != 2:
             raise ValueError("source/target must be matching (N, 2) arrays")
         if use_ransac and len(src) >= 4:
+            # Prefer forward RANSAC (src→dst). Fall back to inverse-then-invert,
+            # then to a plain least-squares fit.
+            m, _ = cv2.findHomography(
+                src, dst, cv2.RANSAC, ransacReprojThreshold=ransac_thresh
+            )
+            if m is not None:
+                self.m = m
+                return
             m_inv, _ = cv2.findHomography(
                 dst, src, cv2.RANSAC, ransacReprojThreshold=ransac_thresh
             )

--- a/sports/common/homography.py
+++ b/sports/common/homography.py
@@ -1,0 +1,229 @@
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import cv2
+import numpy as np
+import numpy.typing as npt
+import supervision as sv
+
+from sports.common.view import ViewTransformer
+from sports.configs.soccer import SoccerPitchConfiguration
+
+HOMOGRAPHY_RANSAC_REPROJ_THRESH = 10.0
+DISPLAY_MIN_KEYPOINTS = 4
+PITCH_CONFIG = SoccerPitchConfiguration()
+
+
+class RansacViewTransformer(ViewTransformer):
+    """ViewTransformer that optionally fits homography with RANSAC."""
+
+    def __init__(
+        self,
+        source: npt.NDArray,
+        target: npt.NDArray,
+        use_ransac: bool = True,
+        ransac_thresh: float = HOMOGRAPHY_RANSAC_REPROJ_THRESH,
+    ) -> None:
+        """
+        Initialize from matching source and target point pairs.
+
+        Args:
+            source (npt.NDArray): Image-space points with shape (N, 2).
+            target (npt.NDArray): Pitch-space points with shape (N, 2).
+            use_ransac (bool): Fit with RANSAC when at least four points exist.
+            ransac_thresh (float): RANSAC reprojection threshold in pixels.
+        """
+        src = np.asarray(source, dtype=np.float32)
+        dst = np.asarray(target, dtype=np.float32)
+        if src.shape != dst.shape or src.ndim != 2 or src.shape[1] != 2:
+            raise ValueError("source/target must be matching (N, 2) arrays")
+        if use_ransac and len(src) >= 4:
+            m_inv, _ = cv2.findHomography(
+                dst, src, cv2.RANSAC, ransacReprojThreshold=ransac_thresh
+            )
+            if m_inv is not None:
+                try:
+                    self.m = np.linalg.inv(m_inv)
+                    return
+                except np.linalg.LinAlgError:
+                    pass
+        m, _ = cv2.findHomography(src, dst)
+        if m is None:
+            raise ValueError("Homography matrix could not be calculated.")
+        self.m = m
+
+
+def pitch_vertex_count(config: SoccerPitchConfiguration = PITCH_CONFIG) -> int:
+    """Return the number of pitch template vertices."""
+    return len(config.vertices)
+
+
+def align_pitch_keypoints(
+    keypoints: sv.KeyPoints,
+    n_vertices: Optional[int] = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Normalize keypoint arrays to the pitch template vertex count.
+
+    Args:
+        keypoints (sv.KeyPoints): Input pitch keypoints.
+        n_vertices (Optional[int]): Target vertex count.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: xy and confidence arrays.
+    """
+    n = n_vertices or pitch_vertex_count()
+    if keypoints.xy.shape[0] == 0:
+        return np.zeros((n, 2), dtype=np.float32), np.zeros(n, dtype=np.float32)
+    xy = keypoints.xy[0].astype(np.float32)
+    if keypoints.confidence is None:
+        conf = np.ones(len(xy), dtype=np.float32)
+    else:
+        conf = keypoints.confidence[0].astype(np.float32)
+    if len(conf) < n:
+        conf = np.pad(conf, (0, n - len(conf)))
+    else:
+        conf = conf[:n]
+    if xy.shape[0] < n:
+        xy = np.pad(xy, ((0, n - xy.shape[0]), (0, 0)), constant_values=0)
+    elif xy.shape[0] > n:
+        xy = xy[:n]
+    return xy, conf
+
+
+def pitch_keypoint_accept_mask(
+    xy: np.ndarray,
+    conf: np.ndarray,
+    confidence: float = 0.5,
+) -> np.ndarray:
+    """
+    Return a mask of keypoints accepted for homography fitting.
+
+    Args:
+        xy (np.ndarray): Keypoint coordinates.
+        conf (np.ndarray): Keypoint confidence scores.
+        confidence (float): Minimum confidence threshold.
+
+    Returns:
+        np.ndarray: Boolean mask aligned with keypoint rows.
+    """
+    n = len(conf)
+    if n == 0:
+        return np.zeros(0, dtype=bool)
+    if len(xy) < n:
+        xy = np.pad(xy.astype(np.float32), ((0, n - len(xy)), (0, 0)), constant_values=0)
+    elif len(xy) > n:
+        xy = xy[:n]
+    return (conf > confidence) & (xy[:, 0] > 1) & (xy[:, 1] > 1)
+
+
+def keypoints_from_inference_field(
+    inference_result: Mapping[str, Any],
+    n_vertices: Optional[int] = None,
+) -> sv.KeyPoints:
+    """
+    Map Roboflow Inference keypoints into fixed pitch vertex slots.
+
+    Args:
+        inference_result (Mapping[str, Any]): Inference API response dict.
+        n_vertices (Optional[int]): Target vertex count.
+
+    Returns:
+        sv.KeyPoints: Keypoints indexed by pitch vertex id.
+    """
+    n = n_vertices or pitch_vertex_count()
+    if hasattr(inference_result, "model_dump"):
+        payload = inference_result.model_dump(by_alias=True, exclude_none=True)
+    elif hasattr(inference_result, "dict"):
+        payload = inference_result.dict(exclude_none=True, by_alias=True)
+    elif isinstance(inference_result, Mapping):
+        payload = inference_result
+    else:
+        return sv.KeyPoints.empty()
+
+    predictions = payload.get("predictions") or []
+    if not predictions:
+        return sv.KeyPoints.empty()
+
+    prediction = max(predictions, key=lambda p: float(p.get("confidence", 0.0)))
+    xy = np.zeros((1, n, 2), dtype=np.float32)
+    conf = np.zeros((1, n), dtype=np.float32)
+
+    for kp in prediction.get("keypoints") or []:
+        idx = int(kp.get("class_id", -1))
+        if idx < 0 or idx >= n:
+            continue
+        xy[0, idx, 0] = float(kp["x"])
+        xy[0, idx, 1] = float(kp["y"])
+        conf[0, idx] = float(kp.get("confidence", 0.0))
+
+    return sv.KeyPoints(xy=xy, confidence=conf)
+
+
+def valid_pitch_cm(
+    xy: np.ndarray,
+    config: SoccerPitchConfiguration = PITCH_CONFIG,
+    margin_cm: float = 200.0,
+) -> np.ndarray:
+    """
+    Return a mask for warped points inside the pitch rectangle.
+
+    Args:
+        xy (np.ndarray): Pitch-space points in centimeters.
+        config (SoccerPitchConfiguration): Pitch configuration.
+        margin_cm (float): Inset margin from pitch edges.
+
+    Returns:
+        np.ndarray: Boolean mask aligned with xy rows.
+    """
+    if xy is None or len(xy) == 0:
+        return np.zeros(0, dtype=bool)
+    finite = np.isfinite(xy).all(axis=1)
+    return (
+        finite
+        & (xy[:, 0] >= margin_cm)
+        & (xy[:, 0] <= config.length - margin_cm)
+        & (xy[:, 1] >= margin_cm)
+        & (xy[:, 1] <= config.width - margin_cm)
+    )
+
+
+def fit_pitch_homography(
+    keypoints: Optional[sv.KeyPoints],
+    config: SoccerPitchConfiguration = PITCH_CONFIG,
+    confidence: float = 0.9,
+    min_keypoints: int = DISPLAY_MIN_KEYPOINTS,
+    use_ransac: bool = False,
+    ransac_thresh: float = HOMOGRAPHY_RANSAC_REPROJ_THRESH,
+) -> Optional[ViewTransformer]:
+    """
+    Fit image-to-pitch homography from pitch keypoints for one frame.
+
+    Args:
+        keypoints (Optional[sv.KeyPoints]): Pitch keypoints for one frame.
+        config (SoccerPitchConfiguration): Pitch configuration.
+        confidence (float): Minimum keypoint confidence.
+        min_keypoints (int): Minimum accepted keypoints required to fit.
+        use_ransac (bool): Whether to use RANSAC during fitting.
+        ransac_thresh (float): RANSAC reprojection threshold in pixels.
+
+    Returns:
+        Optional[ViewTransformer]: Fitted homography, or None when fitting fails.
+    """
+    if keypoints is None or keypoints.xy.shape[0] == 0:
+        return None
+    n = pitch_vertex_count(config)
+    xy, conf = align_pitch_keypoints(keypoints, n_vertices=n)
+    mask = pitch_keypoint_accept_mask(xy, conf, confidence=confidence)
+    if mask.sum() < min_keypoints:
+        return None
+    src = xy[mask].astype(np.float32)
+    dst = np.array(config.vertices, dtype=np.float32)[mask]
+    try:
+        return RansacViewTransformer(
+            source=src,
+            target=dst,
+            use_ransac=use_ransac,
+            ransac_thresh=ransac_thresh,
+        )
+    except ValueError:
+        return None

--- a/sports/common/team.py
+++ b/sports/common/team.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Generator, Iterable, List, TypeVar
 
 import numpy as np

--- a/sports/common/team.py
+++ b/sports/common/team.py
@@ -8,6 +8,8 @@ from sklearn.cluster import KMeans
 from tqdm import tqdm
 from transformers import AutoProcessor, SiglipVisionModel
 
+from sports.configs.soccer import TEAM_NONE
+
 V = TypeVar("V")
 
 SIGLIP_MODEL_PATH = 'google/siglip-base-patch16-224'
@@ -110,3 +112,93 @@ class TeamClassifier:
         data = self.extract_features(crops)
         projections = self.reducer.transform(data)
         return self.cluster_model.predict(projections)
+
+
+def lock_teams_by_tracklet_majority(
+    frames: list[tuple[int, sv.Detections]],
+) -> dict[int, int]:
+    """Lock one team per tracker id using a majority shirt-colour vote.
+
+    Args:
+        frames: Sequence of ``(frame_idx, detections)`` pairs from a clip.
+
+    Returns:
+        Mapping of ``tracker_id`` to locked team id (0 or 1).
+    """
+    votes: dict[int, list[int]] = {}
+    for _, dets in frames:
+        if dets.tracker_id is None or dets.data is None:
+            continue
+        team = np.asarray(
+            dets.data.get("team", np.full(len(dets), TEAM_NONE)), dtype=int
+        )
+        for i, tid in enumerate(dets.tracker_id):
+            tid = int(tid)
+            if tid < 0:
+                continue
+            raw = int(team[i])
+            if raw in (0, 1):
+                votes.setdefault(tid, []).append(raw)
+
+    locked: dict[int, int] = {}
+    for tid, vals in votes.items():
+        counts = np.bincount(np.asarray(vals, dtype=int), minlength=2)
+        locked[tid] = int(np.argmax(counts))
+    return locked
+
+
+def apply_team_lock(
+    team_arr: np.ndarray,
+    tracker_id: np.ndarray | None,
+    team_lock: dict[int, int],
+) -> np.ndarray:
+    """Override team ids with a clip-level majority lock keyed on tracker id.
+
+    Args:
+        team_arr (np.ndarray): Per-detection team ids (modified in place).
+        tracker_id (np.ndarray | None): Per-detection tracker ids.
+        team_lock (dict[int, int]): Clip-level {tracker_id: team} mapping.
+
+    Returns:
+        np.ndarray: The updated team_arr.
+    """
+    if tracker_id is None or not team_lock:
+        return team_arr
+    for i, tid in enumerate(tracker_id):
+        tid = int(tid)
+        if tid in team_lock:
+            team_arr[i] = team_lock[tid]
+    return team_arr
+
+
+def relock_detection_teams(
+    dets: sv.Detections, team_lock: dict[int, int]
+) -> sv.Detections:
+    """Return detections with ``data['team']`` re-locked to the clip-level mapping.
+
+    Args:
+        dets: Input detections.
+        team_lock: Clip-level ``{tracker_id: team}`` mapping.
+
+    Returns:
+        New detections with updated team data, or ``dets`` unchanged when empty.
+    """
+    if not team_lock or dets.tracker_id is None or len(dets) == 0:
+        return dets
+    team = np.asarray(
+        dets.data.get("team", np.full(len(dets), TEAM_NONE))
+        if dets.data
+        else np.full(len(dets), TEAM_NONE),
+        dtype=int,
+    )
+    team = apply_team_lock(team, dets.tracker_id, team_lock)
+    data = dict(dets.data) if dets.data else {}
+    data["team"] = team
+    return sv.Detections(
+        xyxy=dets.xyxy,
+        class_id=dets.class_id,
+        tracker_id=dets.tracker_id,
+        confidence=dets.confidence,
+        data=data,
+    )
+

--- a/sports/configs/soccer.py
+++ b/sports/configs/soccer.py
@@ -92,3 +92,14 @@ class SoccerPitchConfiguration:
         "#FF6347", "#FF6347", "#FF6347", "#FF6347", "#FF6347", "#FF6347",
         "#00BFFF", "#00BFFF"
     ])
+
+
+# Detection class ids — matches examples/soccer and Inference football models.
+BALL_CLASS_ID = 0
+GOALKEEPER_CLASS_ID = 1
+PLAYER_CLASS_ID = 2
+REFEREE_CLASS_ID = 3
+
+TEAM_NONE = -1
+TEAM_LEFT = 0
+TEAM_RIGHT = 1


### PR DESCRIPTION
## What does this PR do?

Add class/team ids, text drawing helper, team lock helpers, and core pitch homography fitting. Example main.py imports shared class ids; legacy modes unchanged.

## Stack

These soccer analytics PRs merge in order: [#59](https://github.com/roboflow/sports/pull/59) → [#60](https://github.com/roboflow/sports/pull/60) → [#61](https://github.com/roboflow/sports/pull/61) → [#63](https://github.com/roboflow/sports/pull/63) → [#64](https://github.com/roboflow/sports/pull/64) → [#65](https://github.com/roboflow/sports/pull/65) → [#66](https://github.com/roboflow/sports/pull/66) → [#67](https://github.com/roboflow/sports/pull/67). Each later PR targets the previous branch.

## Demo

No new example mode in this PR (shared library foundation only). Mode demo renders start in [PR 2 — DIRECTION](https://github.com/roboflow/sports/pull/60). All preview clips: [soccer-analytics-pr-demos release](https://github.com/roboflow/sports/releases/tag/soccer-analytics-pr-demos).

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)