### PR TITLE
feat: add DISTANCE mode with traces and leaderboard (PR 4)

### DIFF
--- a/examples/soccer/README.md
+++ b/examples/soccer/README.md
@@ -135,10 +135,9 @@ on the field.
   Pitch keypoints are cached on disk like player detections. Optional:
   `--pitch-detector`, `--pitch-model-path`, `--pitch-model-id`.
 
-- `DISTANCE` — Same overlays as SPEED, plus cumulative distance chips (m),
+- `DISTANCE` — Direction dots (same as DIRECTION) plus cumulative distance chips (m),
   per-player trace lines on the radar minimap, and a 3-second distance
-  leaderboard end-card. Distance integrates via gated pitch homography
-  (speed badges still use gap-filled homography).
+  leaderboard end-card. No m/s badges. Distance integrates via gated pitch homography.
 
   ```bash
   python main.py --source_video_path data/2e57b9_0.mp4 \

--- a/examples/soccer/README.md
+++ b/examples/soccer/README.md
@@ -135,6 +135,19 @@ on the field.
   Pitch keypoints are cached on disk like player detections. Optional:
   `--pitch-detector`, `--pitch-model-path`, `--pitch-model-id`.
 
+- `DISTANCE` — Same overlays as SPEED, plus cumulative distance chips (m),
+  per-player trace lines on the radar minimap, and a 3-second distance
+  leaderboard end-card. Distance integrates via gated pitch homography
+  (speed badges still use gap-filled homography).
+
+  ```bash
+  python main.py --source_video_path data/2e57b9_0.mp4 \
+  --target_video_path data/renders/2e57b9_0-distance.mp4 \
+  --device mps --mode DISTANCE --max-frames 90
+  ```
+
+  Requires pitch keypoints (same flags as SPEED).
+
 ## 🗺️ roadmap
 
 - [ ] Add smoothing to eliminate flickering in RADAR mode.

--- a/examples/soccer/distance.py
+++ b/examples/soccer/distance.py
@@ -4,10 +4,12 @@ import supervision as sv
 
 from sports.annotators.motion import (
     build_trace_minimap,
+    dim_frame,
     draw_distance_end_card,
     draw_distance_labels,
     draw_speed_legend,
     overlay_minimap,
+    spotlight,
 )
 from sports.common.kinematics import (
     JoystickDotSmoother,
@@ -28,10 +30,16 @@ def run_distance(args, session=None) -> None:
     """Render speed + distance chips, trace minimap, and distance leaderboard end-card."""
     if session is None:
         session = build_video_tracking_session(args, need_homography=True)
-    _render_distance(args, session)
+    _render_speed_distance_traces(args, session, append_end_card=True)
 
 
-def _render_distance(args, session: VideoTrackingSession) -> None:
+def _render_speed_distance_traces(
+    args,
+    session: VideoTrackingSession,
+    *,
+    focus_tid: int | None = None,
+    append_end_card: bool = False,
+) -> None:
     fps, width, height = session.fps, session.width, session.height
     gap_filled = session.gap_filled_transforms_by_frame
     minimap_transforms = session.minimap_transforms_by_frame
@@ -74,10 +82,13 @@ def _render_distance(args, session: VideoTrackingSession) -> None:
                         tid = int(tid)
                         if tid < 0:
                             continue
+                        if focus_tid is not None and tid != focus_tid:
+                            continue
                         trace_by_tid.setdefault(tid, []).append(xy_cm[i].copy())
 
                 speed_by_tid = _speed_by_tid(
                     dets, gap_filled.get(frame_idx), fps, speed_smoother,
+                    only_tid=focus_tid,
                 )
 
                 dist_by_tid: dict[int, float] = {}
@@ -91,22 +102,48 @@ def _render_distance(args, session: VideoTrackingSession) -> None:
                         if dist is not None:
                             dist_by_tid[tid] = dist
 
-                annotated = frame.copy()
-                _annotate_speed_overlay(
-                    annotated, dets, speed_by_tid, joy_smoother, show_legend=False,
-                )
-                draw_distance_labels(annotated, dets, dist_by_tid)
-                draw_speed_legend(annotated)
-                mini_radar = build_trace_minimap(
-                    dets, radar_h, trace_by_tid, None,
-                )
-                overlay_minimap(annotated, mini_radar)
+                radar_transformer = radar_h
+                if focus_tid is not None:
+                    spotlight_mask = (
+                        dets.tracker_id == focus_tid
+                        if dets.tracker_id is not None
+                        else np.zeros(len(dets), dtype=bool)
+                    )
+                    visible = bool(spotlight_mask.any())
+                    if visible:
+                        box = dets.xyxy[spotlight_mask][0]
+                        cx_f = int((box[0] + box[2]) / 2)
+                        cy_f = int(box[3])
+                        annotated = spotlight(frame, cx_f, cy_f)
+                    else:
+                        annotated = dim_frame(frame)
+                    marked = dets[spotlight_mask]
+                    _annotate_speed_overlay(
+                        annotated, marked, speed_by_tid, joy_smoother, show_legend=False,
+                    )
+                    draw_distance_labels(annotated, marked, dist_by_tid)
+                    mini_radar = build_trace_minimap(
+                        dets, radar_transformer, trace_by_tid, focus_tid,
+                    )
+                    overlay_minimap(annotated, mini_radar)
+                else:
+                    annotated = frame.copy()
+                    _annotate_speed_overlay(
+                        annotated, dets, speed_by_tid, joy_smoother, show_legend=False,
+                    )
+                    draw_distance_labels(annotated, dets, dist_by_tid)
+                    draw_speed_legend(annotated)
+                    mini_radar = build_trace_minimap(
+                        dets, radar_transformer, trace_by_tid, None,
+                    )
+                    overlay_minimap(annotated, mini_radar)
                 sink.write_frame(annotated)
 
-            end_card = draw_distance_end_card(width, height, raw_tracks)
-            n_end_frames = max(1, int(fps * 3))
-            for _ in range(n_end_frames):
-                sink.write_frame(end_card)
+            if append_end_card:
+                end_card = draw_distance_end_card(width, height, raw_tracks)
+                n_end_frames = max(1, int(fps * 3))
+                for _ in range(n_end_frames):
+                    sink.write_frame(end_card)
     finally:
         cap.release()
 

--- a/examples/soccer/distance.py
+++ b/examples/soccer/distance.py
@@ -93,6 +93,7 @@ def _render_speed_distance_traces(
                     tracked,
                     locks=locks,
                     vel_smoother=vel_smoother,
+                    frame_idx=frame_idx,
                 )
 
                 radar_h = minimap_transforms.get(frame_idx)

--- a/examples/soccer/distance.py
+++ b/examples/soccer/distance.py
@@ -3,10 +3,12 @@ import numpy as np
 import supervision as sv
 
 from sports.annotators.motion import (
+    annotate_team_ellipses,
     build_trace_minimap,
     dim_frame,
     draw_distance_end_card,
     draw_distance_labels,
+    draw_joystick_dots,
     draw_speed_legend,
     overlay_minimap,
     spotlight,
@@ -27,16 +29,35 @@ from speed import (
 
 
 def run_distance(args, session=None) -> None:
-    """Render speed + distance chips, trace minimap, and distance leaderboard end-card."""
+    """Render direction dots + distance chips, trace minimap, and distance leaderboard end-card."""
     if session is None:
         session = build_video_tracking_session(args, need_homography=True)
-    _render_speed_distance_traces(args, session, append_end_card=True)
+    _render_speed_distance_traces(args, session, show_speed=False, append_end_card=True)
+
+
+def _annotate_player_overlay(
+    frame: np.ndarray,
+    dets: sv.Detections,
+    joy_smoother: JoystickDotSmoother,
+    speed_by_tid: dict[int, float],
+    *,
+    show_speed: bool,
+) -> None:
+    """Team ellipses + direction dots; optional m/s badges when show_speed."""
+    if show_speed:
+        _annotate_speed_overlay(
+            frame, dets, speed_by_tid, joy_smoother, show_legend=False,
+        )
+    else:
+        annotate_team_ellipses(frame, dets)
+        draw_joystick_dots(frame, dets, joy_smoother)
 
 
 def _render_speed_distance_traces(
     args,
     session: VideoTrackingSession,
     *,
+    show_speed: bool = True,
     focus_tid: int | None = None,
     append_end_card: bool = False,
 ) -> None:
@@ -86,10 +107,12 @@ def _render_speed_distance_traces(
                             continue
                         trace_by_tid.setdefault(tid, []).append(xy_cm[i].copy())
 
-                speed_by_tid = _speed_by_tid(
-                    dets, gap_filled.get(frame_idx), fps, speed_smoother,
-                    only_tid=focus_tid,
-                )
+                speed_by_tid: dict[int, float] = {}
+                if show_speed:
+                    speed_by_tid = _speed_by_tid(
+                        dets, gap_filled.get(frame_idx), fps, speed_smoother,
+                        only_tid=focus_tid,
+                    )
 
                 dist_by_tid: dict[int, float] = {}
                 if dets.tracker_id is not None:
@@ -118,8 +141,8 @@ def _render_speed_distance_traces(
                     else:
                         annotated = dim_frame(frame)
                     marked = dets[spotlight_mask]
-                    _annotate_speed_overlay(
-                        annotated, marked, speed_by_tid, joy_smoother, show_legend=False,
+                    _annotate_player_overlay(
+                        annotated, marked, joy_smoother, speed_by_tid, show_speed=show_speed,
                     )
                     draw_distance_labels(annotated, marked, dist_by_tid)
                     mini_radar = build_trace_minimap(
@@ -128,11 +151,12 @@ def _render_speed_distance_traces(
                     overlay_minimap(annotated, mini_radar)
                 else:
                     annotated = frame.copy()
-                    _annotate_speed_overlay(
-                        annotated, dets, speed_by_tid, joy_smoother, show_legend=False,
+                    _annotate_player_overlay(
+                        annotated, dets, joy_smoother, speed_by_tid, show_speed=show_speed,
                     )
                     draw_distance_labels(annotated, dets, dist_by_tid)
-                    draw_speed_legend(annotated)
+                    if show_speed:
+                        draw_speed_legend(annotated)
                     mini_radar = build_trace_minimap(
                         dets, radar_transformer, trace_by_tid, None,
                     )

--- a/examples/soccer/distance.py
+++ b/examples/soccer/distance.py
@@ -1,0 +1,113 @@
+import cv2
+import numpy as np
+import supervision as sv
+
+from sports.annotators.motion import (
+    build_trace_minimap,
+    draw_distance_end_card,
+    draw_distance_labels,
+    draw_speed_legend,
+    overlay_minimap,
+)
+from sports.common.kinematics import (
+    JoystickDotSmoother,
+    KalmanVelocitySmoother,
+    cumulative_distance_at_frame,
+    feet_xy,
+)
+from sports.common.tracking import open_video
+from sports.common.video_tracking import VideoTrackingSession, build_video_tracking_session
+from speed import (
+    KalmanSpeedDisplaySmoother,
+    _annotate_speed_overlay,
+    _speed_by_tid,
+)
+
+
+def run_distance(args, session=None) -> None:
+    """Render speed + distance chips, trace minimap, and distance leaderboard end-card."""
+    if session is None:
+        session = build_video_tracking_session(args, need_homography=True)
+    _render_distance(args, session)
+
+
+def _render_distance(args, session: VideoTrackingSession) -> None:
+    fps, width, height = session.fps, session.width, session.height
+    gap_filled = session.gap_filled_transforms_by_frame
+    minimap_transforms = session.minimap_transforms_by_frame
+    locks = session.team_locks()
+    raw_tracks = session.tracks
+    tracked_lookup = session.tracked_by_frame()
+
+    vel_smoother = KalmanVelocitySmoother(alpha=0.3)
+    speed_smoother = KalmanSpeedDisplaySmoother(alpha=0.3)
+    joy_smoother = JoystickDotSmoother(alpha=0.32)
+    trace_by_tid: dict[int, list[np.ndarray]] = {}
+
+    cap, _, _, _ = open_video(args.source_video_path)
+    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    try:
+        with sv.VideoSink(args.target_video_path, sv.VideoInfo(width, height, fps)) as sink:
+            frame_idx = 0
+            while True:
+                ret, frame = cap.read()
+                if not ret:
+                    break
+                frame_idx += 1
+                if args.max_frames is not None and frame_idx > args.max_frames:
+                    break
+
+                tracked = tracked_lookup.get(frame_idx)
+                if tracked is None:
+                    tracked = sv.Detections.empty()
+                dets = session.apply_replay_teams(
+                    tracked,
+                    locks=locks,
+                    vel_smoother=vel_smoother,
+                )
+
+                radar_h = minimap_transforms.get(frame_idx)
+                if radar_h is not None and dets.tracker_id is not None:
+                    fxy = feet_xy(dets)
+                    xy_cm = radar_h.transform_points(fxy.astype(np.float32))
+                    for i, tid in enumerate(dets.tracker_id):
+                        tid = int(tid)
+                        if tid < 0:
+                            continue
+                        trace_by_tid.setdefault(tid, []).append(xy_cm[i].copy())
+
+                speed_by_tid = _speed_by_tid(
+                    dets, gap_filled.get(frame_idx), fps, speed_smoother,
+                )
+
+                dist_by_tid: dict[int, float] = {}
+                if dets.tracker_id is not None:
+                    for tid in dets.tracker_id:
+                        tid = int(tid)
+                        track = raw_tracks.get(tid)
+                        if track is None:
+                            continue
+                        dist = cumulative_distance_at_frame(track, frame_idx)
+                        if dist is not None:
+                            dist_by_tid[tid] = dist
+
+                annotated = frame.copy()
+                _annotate_speed_overlay(
+                    annotated, dets, speed_by_tid, joy_smoother, show_legend=False,
+                )
+                draw_distance_labels(annotated, dets, dist_by_tid)
+                draw_speed_legend(annotated)
+                mini_radar = build_trace_minimap(
+                    dets, radar_h, trace_by_tid, None,
+                )
+                overlay_minimap(annotated, mini_radar)
+                sink.write_frame(annotated)
+
+            end_card = draw_distance_end_card(width, height, raw_tracks)
+            n_end_frames = max(1, int(fps * 3))
+            for _ in range(n_end_frames):
+                sink.write_frame(end_card)
+    finally:
+        cap.release()
+
+    print(f"Wrote {args.target_video_path}")

--- a/examples/soccer/main.py
+++ b/examples/soccer/main.py
@@ -25,6 +25,7 @@ from sports.configs.soccer import (
 )
 
 from direction import run_direction
+from distance import run_distance
 from speed import run_speed
 
 PARENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -86,9 +87,10 @@ class Mode(Enum):
     RADAR = 'RADAR'
     DIRECTION = 'DIRECTION'
     SPEED = 'SPEED'
+    DISTANCE = 'DISTANCE'
 
 
-ANALYTICS_MODES = (Mode.DIRECTION, Mode.SPEED)
+ANALYTICS_MODES = (Mode.DIRECTION, Mode.SPEED, Mode.DISTANCE)
 
 
 def run_analytics_mode(mode: Mode, args: argparse.Namespace) -> None:
@@ -96,6 +98,8 @@ def run_analytics_mode(mode: Mode, args: argparse.Namespace) -> None:
         run_direction(args)
     elif mode == Mode.SPEED:
         run_speed(args)
+    elif mode == Mode.DISTANCE:
+        run_distance(args)
     else:
         raise NotImplementedError(f"Mode {mode} is not an analytics mode.")
 

--- a/examples/soccer/speed.py
+++ b/examples/soccer/speed.py
@@ -73,6 +73,7 @@ def _speed_by_tid(
     transformer: ViewTransformer | None,
     fps: float,
     speed_smoother: KalmanSpeedDisplaySmoother,
+    only_tid: int | None = None,
 ) -> dict[int, float]:
     speed_by_tid: dict[int, float] = {}
     if dets.tracker_id is None or transformer is None or dets.data is None:
@@ -85,6 +86,8 @@ def _speed_by_tid(
     for i, tid in enumerate(dets.tracker_id):
         tid = int(tid)
         if tid < 0:
+            continue
+        if only_tid is not None and tid != only_tid:
             continue
         vx, vy = float(kf_vx[i]), float(kf_vy[i])
         if not (np.isfinite(vx) and np.isfinite(vy)):

--- a/examples/soccer/speed.py
+++ b/examples/soccer/speed.py
@@ -97,6 +97,24 @@ def _speed_by_tid(
     return speed_by_tid
 
 
+def _annotate_speed_overlay(
+    frame: np.ndarray,
+    dets: sv.Detections,
+    speed_by_tid: dict[int, float],
+    joy_smoother: JoystickDotSmoother,
+    *,
+    show_legend: bool = True,
+) -> None:
+    """Team ellipses + speed badges + optional legend (in-place)."""
+    annotate_team_ellipses(frame, dets)
+    draw_joystick_dots(
+        frame, dets, joy_smoother,
+        speed_by_tid=speed_by_tid, show_speed=True,
+    )
+    if show_legend:
+        draw_speed_legend(frame)
+
+
 def _render_speed(args, session: VideoTrackingSession) -> None:
     fps, width, height = session.fps, session.width, session.height
     gap_filled = session.gap_filled_transforms_by_frame
@@ -135,12 +153,9 @@ def _render_speed(args, session: VideoTrackingSession) -> None:
                 )
 
                 annotated = frame.copy()
-                annotated = annotate_team_ellipses(annotated, dets)
-                draw_joystick_dots(
-                    annotated, dets, joy_smoother,
-                    speed_by_tid=speed_by_tid, show_speed=True,
+                _annotate_speed_overlay(
+                    annotated, dets, speed_by_tid, joy_smoother,
                 )
-                draw_speed_legend(annotated)
                 draw_radar_minimap(
                     annotated, dets, minimap_transforms.get(frame_idx),
                 )

--- a/sports/annotators/motion.py
+++ b/sports/annotators/motion.py
@@ -32,6 +32,8 @@ JOYSTICK_ELLIPSE_THICKNESS = 2.0
 RADAR_MINIMAP_SCALE = 0.065
 RADAR_MINIMAP_PAD = 30
 RADAR_MINIMAP_ALPHA = 0.6
+SPOTLIGHT_RADIUS = 210
+SPOTLIGHT_STRENGTH = 0.88
 # ~18 km/h: highlight sprint-speed badges with a stronger chip border.
 SPEED_SPRINT_MS = 5.0
 _SPEED_BADGE_BG_BGR = (16, 18, 24)
@@ -252,6 +254,27 @@ def draw_speed_legend(frame: np.ndarray) -> None:
         font_scale=scale, color_bgr=(220, 222, 230), thickness=thick,
         font=_CHIP_FONT,
     )
+
+
+def dim_frame(frame: np.ndarray, level: float = 0.22) -> np.ndarray:
+    return np.clip(frame.astype(np.float32) * level, 0, 255).astype(np.uint8)
+
+
+def spotlight(
+    frame: np.ndarray,
+    cx: int,
+    cy: int,
+    radius: int = SPOTLIGHT_RADIUS,
+    strength: float = SPOTLIGHT_STRENGTH,
+) -> np.ndarray:
+    """Dim the frame, then restore the spotlighted player within a soft circle."""
+    dimmed = dim_frame(frame)
+    mask = np.zeros(frame.shape[:2], dtype=np.float32)
+    cv2.circle(mask, (cx, cy), radius, 1.0, -1, cv2.LINE_AA)
+    mask = cv2.GaussianBlur(mask, (0, 0), sigmaX=radius * 0.38)
+    mask = (mask[..., np.newaxis] * strength).astype(np.float32)
+    out = dimmed.astype(np.float32) * (1.0 - mask) + frame.astype(np.float32) * mask
+    return np.clip(out, 0, 255).astype(np.uint8)
 
 
 def overlay_minimap(

--- a/sports/annotators/motion.py
+++ b/sports/annotators/motion.py
@@ -1,10 +1,20 @@
+import colorsys
+
 import cv2
 import numpy as np
 import supervision as sv
 
 from sports.annotators.soccer import draw_pitch, draw_points_on_pitch, player_ellipse_annotator
 from sports.common.draw import draw_text_shadow
-from sports.common.kinematics import DEFAULT_MIN_SPEED_PX, feet_xy, player_mask
+from sports.common.homography import valid_pitch_cm
+from sports.common.kinematics import (
+    DEFAULT_MIN_SPEED_PX,
+    HOMOGRAPHY_PITCH_SMOOTH,
+    PlayerTrack,
+    _smooth_trajectory,
+    feet_xy,
+    player_mask,
+)
 from sports.common.view import ViewTransformer
 from sports.configs.soccer import (
     BALL_CLASS_ID,
@@ -304,3 +314,185 @@ def draw_radar_minimap(
                 )
     overlay_minimap(frame, radar, margin_x=margin_x, margin_y=margin_y, alpha=alpha)
     return frame
+
+
+def _format_distance_value(distance_m: float) -> str:
+    return f"{max(0, int(round(float(distance_m))))} m"
+
+
+def draw_distance_labels(
+    frame: np.ndarray,
+    detections: sv.Detections,
+    distance_by_tid: dict[int, float],
+) -> None:
+    """Draw cumulative distance above each tracked player as a styled chip."""
+    if len(detections) == 0 or detections.tracker_id is None:
+        return
+    teams = (
+        detections.data.get("team", np.full(len(detections), TEAM_NONE))
+        if detections.data else np.full(len(detections), TEAM_NONE)
+    )
+    for i, tid in enumerate(detections.tracker_id):
+        tid = int(tid)
+        if tid < 0:
+            continue
+        dist_m = distance_by_tid.get(tid)
+        if dist_m is None:
+            continue
+        xyxy = detections.xyxy[i]
+        x1, y1, x2 = xyxy[0], xyxy[1], xyxy[2]
+        cx = (float(x1) + float(x2)) / 2.0
+        label = _format_distance_value(dist_m)
+        _, box_h, _vh, _baseline = _chip_box_size(label)
+        cy = float(y1) - 8 - box_h * 0.5
+        team = int(teams[i])
+        team_bgr = _team_color(team).as_bgr()
+        _draw_chip(frame, label, (cx, cy), team_bgr=team_bgr)
+
+
+def track_id_color(tid: int) -> tuple[int, int, int]:
+    """Deterministic BGR color from tracker id."""
+    hue = (tid * 0.618033988749895) % 1.0
+    r, g, b = colorsys.hsv_to_rgb(hue, 0.85, 0.95)
+    return int(b * 255), int(g * 255), int(r * 255)
+
+
+def draw_trace_on_minimap(
+    radar: np.ndarray,
+    trace_cm: np.ndarray,
+    color_bgr: tuple[int, int, int],
+    *,
+    padding: int = RADAR_MINIMAP_PAD,
+    scale: float = RADAR_MINIMAP_SCALE,
+    thickness: int = 2,
+    smooth_window: int | None = None,
+    margin_cm: float = 80.0,
+) -> np.ndarray:
+    """Draw a pitch-cm polyline trace on a minimap image."""
+    window = HOMOGRAPHY_PITCH_SMOOTH if smooth_window is None else smooth_window
+    trace_cm = np.asarray(trace_cm, dtype=np.float64)
+    if trace_cm.ndim == 2 and len(trace_cm):
+        on_pitch = valid_pitch_cm(trace_cm, margin_cm=margin_cm)
+        trace_cm = trace_cm[on_pitch]
+        trace_cm = _smooth_trajectory(trace_cm, window)
+    pts: list[tuple[int, int]] = []
+    for pt in trace_cm:
+        if np.any(np.isnan(pt)):
+            continue
+        px = int(pt[0] * scale) + padding
+        py = int(pt[1] * scale) + padding
+        pts.append((px, py))
+    if len(pts) >= 2:
+        cv2.polylines(radar, [np.array(pts, dtype=np.int32)], False, color_bgr, thickness, cv2.LINE_AA)
+    if pts:
+        cv2.circle(radar, pts[-1], 7, color_bgr, -1, cv2.LINE_AA)
+        cv2.circle(radar, pts[-1], 7, (255, 255, 255), 1, cv2.LINE_AA)
+    return radar
+
+
+def build_trace_minimap(
+    detections: sv.Detections,
+    transformer: ViewTransformer | None,
+    trace_by_tid: dict[int, list[np.ndarray]],
+    focus_tid: int | None = None,
+    *,
+    config=None,
+    scale: float = RADAR_MINIMAP_SCALE,
+    padding: int = RADAR_MINIMAP_PAD,
+) -> np.ndarray:
+    """Build a radar minimap with per-track colored traces and current player dots."""
+    if focus_tid is not None:
+        focus_tid = int(focus_tid)
+
+    if config is None:
+        config = SoccerPitchConfiguration()
+    radar = draw_pitch(config=config, padding=padding, scale=scale)
+
+    if focus_tid is None:
+        trace_items = trace_by_tid.items()
+    else:
+        pts = trace_by_tid.get(focus_tid)
+        trace_items = ((focus_tid, pts),) if pts is not None else ()
+    for tid, pts in trace_items:
+        if len(pts) < 2:
+            continue
+        trace = np.stack(pts, axis=0)
+        color = track_id_color(int(tid))
+        radar = draw_trace_on_minimap(radar, trace, color, padding=padding, scale=scale)
+
+    if transformer is not None and len(detections):
+        pmask = player_mask(detections)
+        if pmask.any():
+            pdet = detections[pmask]
+            if focus_tid is not None and pdet.tracker_id is not None:
+                focus_mask = pdet.tracker_id == focus_tid
+                pdet = pdet[focus_mask] if focus_mask.any() else sv.Detections.empty()
+            if len(pdet) == 0:
+                return radar
+            xy = feet_xy(pdet).astype(np.float32)
+            xy_cm = transformer.transform_points(xy)
+            on_pitch = valid_pitch_cm(xy_cm, config, margin_cm=80.0)
+            tids_p = pdet.tracker_id if pdet.tracker_id is not None else np.full(len(pdet), -1)
+            teams = (
+                pdet.data.get("team", np.full(len(pdet), TEAM_NONE))
+                if pdet.data else np.full(len(pdet), TEAM_NONE)
+            )
+            for i in range(len(pdet)):
+                if not on_pitch[i]:
+                    continue
+                t_id = int(tids_p[i])
+                team = int(teams[i])
+                if team in (0, 1):
+                    color = TEAM_COLORS[team].as_bgr()
+                else:
+                    color = track_id_color(t_id) if t_id >= 0 else (150, 150, 150)
+                pt_cm = xy_cm[i]
+                px = int(pt_cm[0] * scale) + padding
+                py = int(pt_cm[1] * scale) + padding
+                cv2.circle(radar, (px, py), 8, color, -1, cv2.LINE_AA)
+                cv2.circle(radar, (px, py), 8, (255, 255, 255), 1, cv2.LINE_AA)
+    return radar
+
+
+def draw_distance_end_card(
+    width: int,
+    height: int,
+    tracks: dict[int, PlayerTrack],
+    *,
+    n_top: int = 10,
+) -> np.ndarray:
+    """Black end-card with distance leaderboard."""
+    card = np.zeros((height, width, 3), dtype=np.uint8)
+    title = "DISTANCE LEADERBOARD"
+    cv2.putText(
+        card, title, (40, 60), cv2.FONT_HERSHEY_DUPLEX, 1.2,
+        (255, 255, 255), 2, cv2.LINE_AA,
+    )
+    cv2.line(card, (40, 80), (width - 40, 80), (120, 120, 120), 1)
+
+    ranked = sorted(
+        ((tid, t.distance_m) for tid, t in tracks.items()),
+        key=lambda x: x[1],
+        reverse=True,
+    )[:n_top]
+
+    y = 130
+    for rank, (tid, dist_m) in enumerate(ranked, 1):
+        label = f"#{rank:2d}   Track {tid:4d}   {dist_m:7.1f} m"
+        color = (255, 215, 0) if rank == 1 else (200, 200, 200)
+        cv2.putText(
+            card, label, (60, y), cv2.FONT_HERSHEY_SIMPLEX, 0.75, color, 1, cv2.LINE_AA,
+        )
+        y += 46
+
+    cv2.putText(
+        card,
+        "Distance measured via gated pitch homography",
+        (40, height - 30),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.42,
+        (90, 90, 90),
+        1,
+        cv2.LINE_AA,
+    )
+    return card

--- a/sports/common/homography.py
+++ b/sports/common/homography.py
@@ -342,3 +342,22 @@ def gap_fill_speed_transforms(
         if t is not None:
             filled[int(fi)] = t
     return filled
+
+
+def valid_pitch_cm(
+    xy: np.ndarray,
+    config: SoccerPitchConfiguration = PITCH_CONFIG,
+    *,
+    margin_cm: float = 200.0,
+) -> np.ndarray:
+    """Mask for warped points that fall inside the pitch rectangle (drops outliers)."""
+    if xy is None or len(xy) == 0:
+        return np.zeros(0, dtype=bool)
+    finite = np.isfinite(xy).all(axis=1)
+    return (
+        finite
+        & (xy[:, 0] >= margin_cm)
+        & (xy[:, 0] <= config.length - margin_cm)
+        & (xy[:, 1] >= margin_cm)
+        & (xy[:, 1] <= config.width - margin_cm)
+    )

--- a/sports/common/kinematics.py
+++ b/sports/common/kinematics.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass, field
+from typing import Any
+
 import numpy as np
 import supervision as sv
 from trackers.utils.state_representations import XCYCWHStateEstimator, XYXYStateEstimator
@@ -5,6 +8,9 @@ from trackers.utils.state_representations import XCYCWHStateEstimator, XYXYState
 from sports.configs.soccer import GOALKEEPER_CLASS_ID, PLAYER_CLASS_ID
 
 DEFAULT_MIN_SPEED_PX = 0.5
+MAX_PHYSICAL_STEP_MS = 12.5
+HOMOGRAPHY_PITCH_SMOOTH = 9
+HOMOGRAPHY_XY_SMOOTH = 5
 
 
 def feet_xy(detections: sv.Detections) -> np.ndarray:
@@ -159,3 +165,147 @@ class JoystickDotSmoother:
             oy = a * oy + (1.0 - a) * poy
         self._offset[tracker_id] = (ox, oy)
         return int(round(cx + ox)), int(round(cy + oy))
+
+
+@dataclass
+class PlayerTrack:
+    track_id: int
+    frames: list[int] = field(default_factory=list)
+    xy: list[tuple[float, float]] = field(default_factory=list)
+    box_h: list[float] = field(default_factory=list)
+    distance_m: float = 0.0
+    cumulative_m: np.ndarray | None = None
+
+
+def collect_tracks(detections_iter) -> dict[int, PlayerTrack]:
+    """Accumulate per-track feet positions from a (frame_idx, detections) iterator."""
+    tracks: dict[int, PlayerTrack] = {}
+    for frame_idx, dets in detections_iter:
+        if dets.tracker_id is None or len(dets) == 0:
+            continue
+        pmask = player_mask(dets)
+        if not pmask.any():
+            continue
+        fxy = feet_xy(dets)
+        heights = dets.xyxy[:, 3] - dets.xyxy[:, 1]
+        for i in np.flatnonzero(pmask):
+            tid = int(dets.tracker_id[i])
+            if tid < 0:
+                continue
+            track = tracks.setdefault(tid, PlayerTrack(tid))
+            track.frames.append(int(frame_idx))
+            track.xy.append((float(fxy[i, 0]), float(fxy[i, 1])))
+            track.box_h.append(float(heights[i]))
+    return tracks
+
+
+def _smooth_xy(xy: np.ndarray, window: int) -> np.ndarray:
+    """Moving-average smooth an (N, 2) trajectory."""
+    if len(xy) < 2 or window <= 1:
+        return xy
+    pad = window // 2
+    out = xy.copy()
+    for k in range(2):
+        col = xy[:, k]
+        padded = np.pad(col, pad, mode="edge")
+        out[:, k] = np.array([np.mean(padded[i:i + window]) for i in range(len(col))])
+    return out
+
+
+def _smooth_trajectory(pos: np.ndarray, window: int) -> np.ndarray:
+    """Median-smooth (N, 2) pitch positions; NaN-filled from track median first."""
+    if len(pos) < 2 or window <= 1:
+        return pos
+    out = pos.copy()
+    for k in range(2):
+        col = out[:, k].copy()
+        valid = np.isfinite(col)
+        if not valid.any():
+            continue
+        col[~valid] = float(np.median(col[valid]))
+        pad = window // 2
+        padded = np.pad(col, pad, mode="edge")
+        out[:, k] = np.array([np.median(padded[i:i + window]) for i in range(len(col))])
+    return out
+
+
+def _pitch_positions(
+    xy: np.ndarray,
+    frames: np.ndarray,
+    frame_transforms: dict,
+) -> np.ndarray:
+    """Per-sample pitch positions (m) warped with that frame's homography."""
+    n = len(frames)
+    pos = np.full((n, 2), np.nan, dtype=np.float64)
+    for i in range(n):
+        t = frame_transforms.get(int(frames[i]))
+        if t is None:
+            continue
+        pt = t.transform_points(xy[i].reshape(1, 2).astype(np.float32))[0]
+        pos[i] = pt / 100.0
+    return pos
+
+
+def _distance_from_smoothed(
+    pos: np.ndarray,
+    frames: np.ndarray,
+    fps: float,
+    *,
+    pitch_smooth: int = HOMOGRAPHY_PITCH_SMOOTH,
+    max_step_ms: float = MAX_PHYSICAL_STEP_MS,
+) -> tuple[float, np.ndarray]:
+    """Smooth pitch trajectory then integrate 1-frame hops."""
+    smooth_pos = _smooth_trajectory(pos, pitch_smooth)
+    n = len(frames)
+    step_m = np.zeros(max(n - 1, 0), dtype=np.float64)
+    for j in range(1, n):
+        if np.any(np.isnan(smooth_pos[j])) or np.any(np.isnan(smooth_pos[j - 1])):
+            continue
+        dt = (int(frames[j]) - int(frames[j - 1])) / fps
+        if dt <= 0:
+            continue
+        dist = float(np.linalg.norm(smooth_pos[j] - smooth_pos[j - 1]))
+        if dist / dt <= max_step_ms:
+            step_m[j - 1] = dist
+    return float(np.sum(step_m)), step_m
+
+
+def compute_kinematics(
+    tracks: dict[int, PlayerTrack],
+    fps: float,
+    *,
+    mode: str = "homography",
+    frame_transforms: dict[int, Any] | None = None,
+    min_frames: int = 2,
+) -> dict[int, PlayerTrack]:
+    """Compute cumulative distance for each track via gated homography."""
+    for track in tracks.values():
+        if len(track.frames) < min_frames:
+            track.distance_m = 0.0
+            track.cumulative_m = np.zeros(len(track.frames))
+            continue
+
+        xy = np.asarray(track.xy, dtype=np.float64)
+        frames = np.asarray(track.frames)
+        transforms = frame_transforms or {}
+
+        if mode == "homography" and transforms:
+            xy = _smooth_xy(xy, HOMOGRAPHY_XY_SMOOTH)
+            pos = _pitch_positions(xy, frames, transforms)
+            dist_m, step_m = _distance_from_smoothed(pos, frames, fps)
+            track.distance_m = dist_m
+            cum = np.zeros(len(frames), dtype=np.float64)
+            for j in range(len(step_m)):
+                cum[j + 1] = cum[j] + step_m[j]
+            track.cumulative_m = cum
+        else:
+            track.distance_m = 0.0
+            track.cumulative_m = np.zeros(len(track.frames))
+    return tracks
+
+
+def cumulative_distance_at_frame(track: PlayerTrack, frame_idx: int) -> float | None:
+    """Running distance (m) at frame_idx after compute_kinematics."""
+    if track.cumulative_m is None or frame_idx not in track.frames:
+        return None
+    return float(track.cumulative_m[track.frames.index(frame_idx)])

--- a/sports/common/video_tracking.py
+++ b/sports/common/video_tracking.py
@@ -18,6 +18,11 @@ from sports.common.homography import (
     gap_fill_speed_transforms,
     replay_gated_transforms,
 )
+from sports.common.kinematics import (
+    PlayerTrack,
+    collect_tracks,
+    compute_kinematics,
+)
 from sports.common.goalkeeper import apply_goalkeeper_teams, derive_gk_locks
 from sports.common.team import (
     TeamLocks,
@@ -64,6 +69,7 @@ class VideoTrackingSession:
     _speed_transforms: dict | None = field(default=None, repr=False)
     _gap_filled_transforms: dict | None = field(default=None, repr=False)
     _minimap_transforms: dict | None = field(default=None, repr=False)
+    _tracks: dict[int, PlayerTrack] | None = field(default=None, repr=False)
 
     def team_locks(self) -> TeamLocks:
         """Return clip-level team locks, cached."""
@@ -111,6 +117,19 @@ class VideoTrackingSession:
                 raise RuntimeError("pitch keypoints were not computed for this session")
             self._minimap_transforms = build_minimap_transform_map(self.kp_by_frame)
         return self._minimap_transforms
+
+    @property
+    def tracks(self) -> dict[int, PlayerTrack]:
+        """Per-track cumulative distance from gated homography (not gap-filled)."""
+        if self._tracks is None:
+            raw = collect_tracks(self.iter_tracked())
+            self._tracks = compute_kinematics(
+                raw,
+                self.fps,
+                mode="homography",
+                frame_transforms=self._gated_speed_transforms(),
+            )
+        return self._tracks
 
     def iter_tracked(self):
         """Yield frame_idx and tracked detections with blocked ids removed."""


### PR DESCRIPTION
## Summary

- Adds `DISTANCE` mode: direction dots + cumulative meters + trace minimap + distance leaderboard end-card (**no m/s badges**).
- Distance via gated H on `VideoTrackingSession.tracks`.
- Shared `_render_speed_distance_traces(..., show_speed=)` for PR5 reuse.

## Demo

`DISTANCE` on `08fd33_0.mp4` (full-clip render, truncated preview):

<video src="https://github.com/roboflow/sports/releases/download/soccer-analytics-pr-demos/pr4-distance.mp4" controls width="100%"></video>

[All demos](https://github.com/roboflow/sports/releases/tag/soccer-analytics-pr-demos)

## Scope

**In:** `distance.py`, kinematics distance APIs, trace/end-card annotators, `Mode.DISTANCE`

**Out:** combo/ALL wiring (PR5), goal shading draw (PR6)

## Test plan

- [ ] `python main.py ... --mode DISTANCE --tracker bytetrack`
- [ ] Chips + traces + end-card; SPEED/DIRECTION unchanged