### PR TITLE
feat: add minimap goal shading from locked defenders (PR 6)

### DIFF
--- a/examples/soccer/README.md
+++ b/examples/soccer/README.md
@@ -145,7 +145,8 @@ on the field.
   --device mps --mode DISTANCE --max-frames 90
   ```
 
-  Requires pitch keypoints (same flags as SPEED).
+  Requires pitch keypoints (same flags as SPEED). Minimap shows defending-team
+  goal shading when homography locks are available.
 
 - `SPEED_AND_DISTANCE` — Speed + distance chips and per-player trace lines on the
   radar minimap (no end-card). Default shows all players; pass `--track-id N` to

--- a/examples/soccer/distance.py
+++ b/examples/soccer/distance.py
@@ -148,6 +148,7 @@ def _render_speed_distance_traces(
                     draw_distance_labels(annotated, marked, dist_by_tid)
                     mini_radar = build_trace_minimap(
                         dets, radar_transformer, trace_by_tid, focus_tid,
+                        locked_goal_defenders=locks.locked_goal_defenders,
                     )
                     overlay_minimap(annotated, mini_radar)
                 else:
@@ -160,6 +161,7 @@ def _render_speed_distance_traces(
                         draw_speed_legend(annotated)
                     mini_radar = build_trace_minimap(
                         dets, radar_transformer, trace_by_tid, None,
+                        locked_goal_defenders=locks.locked_goal_defenders,
                     )
                     overlay_minimap(annotated, mini_radar)
                 sink.write_frame(annotated)

--- a/examples/soccer/speed.py
+++ b/examples/soccer/speed.py
@@ -161,6 +161,7 @@ def _render_speed(args, session: VideoTrackingSession) -> None:
                 )
                 draw_radar_minimap(
                     annotated, dets, minimap_transforms.get(frame_idx),
+                    locked_goal_defenders=locks.locked_goal_defenders,
                 )
                 sink.write_frame(annotated)
     finally:

--- a/sports/annotators/motion.py
+++ b/sports/annotators/motion.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 import supervision as sv
 
-from sports.annotators.soccer import draw_pitch, draw_points_on_pitch, player_ellipse_annotator
+from sports.annotators.soccer import draw_pitch, draw_points_on_pitch, draw_goals_on_pitch, player_ellipse_annotator
 from sports.common.draw import draw_text_shadow
 from sports.common.homography import valid_pitch_cm
 from sports.common.kinematics import (
@@ -305,12 +305,24 @@ def draw_radar_minimap(
     margin_x: int = 12,
     margin_y: int = 12,
     alpha: float = RADAR_MINIMAP_ALPHA,
+    locked_goal_defenders: tuple[int, int] | None = None,
 ) -> np.ndarray:
     """Overlay a plain translucent radar minimap in the bottom-right corner."""
     if transformer is None:
         return frame
     config = SoccerPitchConfiguration()
     radar = draw_pitch(config=config, padding=padding, scale=minimap_scale)
+    if locked_goal_defenders is not None:
+        left_def, right_def = locked_goal_defenders
+        if left_def in (0, 1) and right_def in (0, 1):
+            radar = draw_goals_on_pitch(
+                config,
+                left_defender_team=left_def,
+                right_defender_team=right_def,
+                padding=padding,
+                scale=minimap_scale,
+                pitch=radar,
+            )
     pmask = player_mask(detections)
     if pmask.any():
         pdet = detections[pmask]
@@ -422,6 +434,7 @@ def build_trace_minimap(
     config=None,
     scale: float = RADAR_MINIMAP_SCALE,
     padding: int = RADAR_MINIMAP_PAD,
+    locked_goal_defenders: tuple[int, int] | None = None,
 ) -> np.ndarray:
     """Build a radar minimap with per-track colored traces and current player dots."""
     if focus_tid is not None:
@@ -430,6 +443,17 @@ def build_trace_minimap(
     if config is None:
         config = SoccerPitchConfiguration()
     radar = draw_pitch(config=config, padding=padding, scale=scale)
+    if locked_goal_defenders is not None:
+        left_def, right_def = locked_goal_defenders
+        if left_def in (0, 1) and right_def in (0, 1):
+            radar = draw_goals_on_pitch(
+                config,
+                left_defender_team=left_def,
+                right_defender_team=right_def,
+                padding=padding,
+                scale=scale,
+                pitch=radar,
+            )
 
     if focus_tid is None:
         trace_items = trace_by_tid.items()

--- a/sports/annotators/soccer.py
+++ b/sports/annotators/soccer.py
@@ -107,6 +107,42 @@ def draw_pitch(
     return pitch_image
 
 
+def draw_goals_on_pitch(
+    config: SoccerPitchConfiguration,
+    *,
+    left_defender_team: int,
+    right_defender_team: int,
+    pitch: np.ndarray,
+    padding: int = 50,
+    scale: float = 0.1,
+    fill_alpha: float = 0.38,
+) -> np.ndarray:
+    """Highlight each goal mouth in the defending team's color."""
+    team_colors = [sv.Color.from_hex(c) for c in PLAYER_VIS_COLORS[:2]]
+    w = config.width
+    length = config.length
+    gbw = config.goal_box_width
+    gbl = config.goal_box_length
+    y0, y1 = (w - gbw) / 2, (w + gbw) / 2
+
+    def _goal_patch(goal_x_cm: float, defender: int, depth_cm: float) -> None:
+        color = team_colors[defender % len(team_colors)].as_bgr()
+        mouth_x = int(goal_x_cm * scale) + padding
+        py0 = int(y0 * scale) + padding
+        py1 = int(y1 * scale) + padding
+        inner_x = int((goal_x_cm + depth_cm) * scale) + padding
+        x_lo, x_hi = sorted((mouth_x, inner_x))
+        overlay = pitch.copy()
+        cv2.rectangle(overlay, (x_lo, py0), (x_hi, py1), color, -1)
+        cv2.addWeighted(overlay, fill_alpha, pitch, 1.0 - fill_alpha, 0, pitch)
+        cv2.line(pitch, (mouth_x, py0), (mouth_x, py1), color, 5, cv2.LINE_AA)
+        cv2.line(pitch, (mouth_x, py0), (mouth_x, py1), (255, 255, 255), 1, cv2.LINE_AA)
+
+    _goal_patch(0.0, left_defender_team, gbl)
+    _goal_patch(float(length), right_defender_team, -gbl)
+    return pitch
+
+
 def draw_points_on_pitch(
     config: SoccerPitchConfiguration,
     xy: np.ndarray,


### PR DESCRIPTION
## Summary

- `draw_goals_on_pitch` — shade each goal mouth in the defending team’s colour.
- Passes `locks.locked_goal_defenders` (from PR3) into radar/trace minimaps.
- Shading-only PR (~66 lines of annotator + wiring).

## Demo

`DISTANCE` with goal shading on the trace minimap:

<video src="https://github.com/roboflow/sports/releases/download/soccer-analytics-pr-demos/pr6-goal-shading.mp4" controls width="100%"></video>

[All demos](https://github.com/roboflow/sports/releases/tag/soccer-analytics-pr-demos)

## Design

- GK assignment + `locked_goal_defenders` live on **PR3**.
- This PR only draws the shaded goals.

## Scope

**In:** `draw_goals_on_pitch`, minimap kwargs, thin `speed.py` / `distance.py` pass-through

**Out:** ball / possession / pass analytics (next PRs)

## Test plan

- [ ] `--mode SPEED` / `--mode DISTANCE` — shaded goals on minimap
- [ ] Team ellipse colours match PR3 behaviour