### PR TITLE
Add PASS_ALTERNATIVES + PASS_COMPLETE detect/suggest demos (PR8)

### DIFF
--- a/examples/soccer/README.md
+++ b/examples/soccer/README.md
@@ -177,11 +177,22 @@ on the field.
   --device mps --mode PASS_NETWORK --tracker bytetrack
   ```
 
+- `PASS_ALTERNATIVES` — Freeze moments with ranked open teammate pass lanes
+  (lane scoring via `pass_options` / `PassQualityScorer`). Opt-in only (not
+  part of `ALL`). Requires ball weights like `PASS_NETWORK`; prefer a full clip.
+
+  ```bash
+  python main.py --source_video_path data/08fd33_0.mp4 \
+  --target_video_path data/renders/08fd33_0-pass-alternatives.mp4 \
+  --device mps --mode PASS_ALTERNATIVES --tracker bytetrack
+  ```
+
 - `ALL` — Runs DIRECTION, SPEED, DISTANCE, SPEED_AND_DISTANCE (all players), and
   SPEED_AND_DISTANCE (spotlight) in one pass. Builds a shared
   `VideoTrackingSession` once; each mode writes a separate `-{suffix}.mp4` next to
   the base `--target_video_path`. Spotlight track is the player with max cumulative
-  distance unless `--track-id` is set. Does **not** include `PASS_NETWORK`.
+  distance unless `--track-id` is set. Does **not** include `PASS_NETWORK` or
+  `PASS_ALTERNATIVES`.
 
   ```bash
   python main.py --source_video_path data/2e57b9_0.mp4 \

--- a/examples/soccer/README.md
+++ b/examples/soccer/README.md
@@ -187,12 +187,21 @@ on the field.
   --device mps --mode PASS_ALTERNATIVES --tracker bytetrack
   ```
 
+- `PASS_COMPLETE` — Detected passes / turnovers / collaboration **plus** freeze
+  reveals of open lanes at each completed-pass release (`--show-predictions`).
+  Same as `PASS_NETWORK --show-predictions`.
+
+  ```bash
+  python main.py --source_video_path data/08fd33_0.mp4 \
+  --target_video_path data/renders/08fd33_0-pass-complete.mp4 \
+  --device mps --mode PASS_COMPLETE --tracker bytetrack
+  ```
+
 - `ALL` — Runs DIRECTION, SPEED, DISTANCE, SPEED_AND_DISTANCE (all players), and
   SPEED_AND_DISTANCE (spotlight) in one pass. Builds a shared
   `VideoTrackingSession` once; each mode writes a separate `-{suffix}.mp4` next to
   the base `--target_video_path`. Spotlight track is the player with max cumulative
-  distance unless `--track-id` is set. Does **not** include `PASS_NETWORK` or
-  `PASS_ALTERNATIVES`.
+  distance unless `--track-id` is set. Does **not** include pass modes.
 
   ```bash
   python main.py --source_video_path data/2e57b9_0.mp4 \

--- a/examples/soccer/README.md
+++ b/examples/soccer/README.md
@@ -178,8 +178,9 @@ on the field.
   ```
 
 - `PASS_ALTERNATIVES` — Freeze moments with ranked open teammate pass lanes
-  (lane scoring via `pass_options` / `PassQualityScorer`). Opt-in only (not
-  part of `ALL`). Requires ball weights like `PASS_NETWORK`; prefer a full clip.
+  (lane scoring via `pass_options` / `PassQualityScorer`; detected passes are
+  not scored). Opt-in only (not part of `ALL`). Requires ball weights like
+  `PASS_NETWORK`; prefer a full clip.
 
   ```bash
   python main.py --source_video_path data/08fd33_0.mp4 \

--- a/examples/soccer/main.py
+++ b/examples/soccer/main.py
@@ -26,6 +26,7 @@ from sports.configs.soccer import (
 
 from direction import run_direction
 from distance import run_distance
+from pass_alternatives import run_pass_alternatives
 from pass_network import run_pass_network
 from run_all import run_all
 from speed import run_speed
@@ -93,12 +94,13 @@ class Mode(Enum):
     DISTANCE = 'DISTANCE'
     SPEED_AND_DISTANCE = 'SPEED_AND_DISTANCE'
     PASS_NETWORK = 'PASS_NETWORK'
+    PASS_ALTERNATIVES = 'PASS_ALTERNATIVES'
     ALL = 'ALL'
 
 
 ANALYTICS_MODES = (
     Mode.DIRECTION, Mode.SPEED, Mode.DISTANCE,
-    Mode.SPEED_AND_DISTANCE, Mode.PASS_NETWORK, Mode.ALL,
+    Mode.SPEED_AND_DISTANCE, Mode.PASS_NETWORK, Mode.PASS_ALTERNATIVES, Mode.ALL,
 )
 
 
@@ -113,6 +115,8 @@ def run_analytics_mode(mode: Mode, args: argparse.Namespace) -> None:
         run_speed_and_distance(args)
     elif mode == Mode.PASS_NETWORK:
         run_pass_network(args)
+    elif mode == Mode.PASS_ALTERNATIVES:
+        run_pass_alternatives(args)
     elif mode == Mode.ALL:
         run_all(args)
     else:

--- a/examples/soccer/main.py
+++ b/examples/soccer/main.py
@@ -95,12 +95,14 @@ class Mode(Enum):
     SPEED_AND_DISTANCE = 'SPEED_AND_DISTANCE'
     PASS_NETWORK = 'PASS_NETWORK'
     PASS_ALTERNATIVES = 'PASS_ALTERNATIVES'
+    PASS_COMPLETE = 'PASS_COMPLETE'
     ALL = 'ALL'
 
 
 ANALYTICS_MODES = (
     Mode.DIRECTION, Mode.SPEED, Mode.DISTANCE,
-    Mode.SPEED_AND_DISTANCE, Mode.PASS_NETWORK, Mode.PASS_ALTERNATIVES, Mode.ALL,
+    Mode.SPEED_AND_DISTANCE, Mode.PASS_NETWORK, Mode.PASS_ALTERNATIVES,
+    Mode.PASS_COMPLETE, Mode.ALL,
 )
 
 
@@ -117,6 +119,9 @@ def run_analytics_mode(mode: Mode, args: argparse.Namespace) -> None:
         run_pass_network(args)
     elif mode == Mode.PASS_ALTERNATIVES:
         run_pass_alternatives(args)
+    elif mode == Mode.PASS_COMPLETE:
+        args.show_predictions = True
+        run_pass_network(args)
     elif mode == Mode.ALL:
         run_all(args)
     else:
@@ -452,8 +457,22 @@ if __name__ == '__main__':
                         help='(analytics) Spotlight a specific tracker id (SPEED_AND_DISTANCE)')
     parser.add_argument('--ball-model-path', dest='ball_model_path', default=None,
                         help='(analytics) Path to YOLO ball detection .pt (PASS_NETWORK)')
+    parser.add_argument(
+        '--show-predictions', dest='show_predictions', action='store_true',
+        help='(PASS_NETWORK / PASS_COMPLETE) Freeze on detected passes and reveal '
+             'ranked open lanes',
+    )
+    parser.add_argument(
+        '--freeze-quality-threshold', dest='freeze_quality_threshold',
+        type=float, default=0.0,
+        help='(PASS_NETWORK) Min detected-pass quality to trigger a prediction freeze',
+    )
 
     args = parser.parse_args()
+    if not hasattr(args, 'show_predictions'):
+        args.show_predictions = False
+    if not hasattr(args, 'freeze_quality_threshold'):
+        args.freeze_quality_threshold = 0.0
 
     if args.mode in ANALYTICS_MODES:
         run_analytics_mode(args.mode, args)

--- a/examples/soccer/main.py
+++ b/examples/soccer/main.py
@@ -465,7 +465,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--freeze-quality-threshold', dest='freeze_quality_threshold',
         type=float, default=0.0,
-        help='(PASS_NETWORK) Min detected-pass quality to trigger a prediction freeze',
+        help='(PASS_NETWORK) Min top alternative-lane score to trigger a prediction freeze',
     )
 
     args = parser.parse_args()

--- a/examples/soccer/pass_alternatives.py
+++ b/examples/soccer/pass_alternatives.py
@@ -1,0 +1,157 @@
+"""PASS_ALTERNATIVES mode: freeze moments with ranked open pass lanes."""
+
+from __future__ import annotations
+
+import supervision as sv
+
+from sports.annotators.passing import (
+    CARRIER_SHADOW_BGR,
+    annotate_ball,
+    annotate_pass_players,
+    draw_carrier_ground_ellipse,
+    draw_hud_bar,
+    draw_pass_alternatives_overlay,
+    draw_radar_minimap,
+)
+from sports.common.kinematics import feet_xy
+from sports.common.pass_alternatives import (
+    DEFAULT_FINAL_OPTION_EXTRA_SECONDS,
+    DEFAULT_FREEZE_SECONDS,
+    DEFAULT_OPTION_REVEAL_SECONDS,
+    DEFAULT_SLOWDOWN_RAMP_SECONDS,
+    slowdown_hold_count,
+)
+from sports.common.pass_pitch import lane_scoring_transformer_for_frame
+from sports.common.possession import find_control_carrier
+from sports.common.tracking import open_video
+from sports.common.video_tracking import VideoTrackingSession, build_video_tracking_session
+
+
+def run_pass_alternatives(args, session: VideoTrackingSession | None = None) -> None:
+    """Render pass-alternative freeze frames to ``args.target_video_path``."""
+    if session is None:
+        session = build_video_tracking_session(args, need_homography=True)
+    _render_pass_alternatives(args, session)
+
+
+def _annotate_live(
+    frame,
+    dets,
+    *,
+    radar_h,
+    locked_goals,
+) -> object:
+    image = frame.copy()
+    image = annotate_pass_players(image, dets, show_tracker_ids=True)
+    image = annotate_ball(image, dets)
+    carrier = find_control_carrier(dets, transformer=radar_h)
+    if carrier is not None:
+        draw_carrier_ground_ellipse(
+            image,
+            feet_xy(dets)[carrier.index],
+            transformer=radar_h,
+            color_bgr=CARRIER_SHADOW_BGR,
+            radius_m=0.5,
+            alpha=0.42,
+            filled=True,
+            thickness=1,
+        )
+    image = draw_radar_minimap(
+        image,
+        dets,
+        radar_h,
+        locked_goal_defenders=locked_goals,
+    )
+    return draw_hud_bar(image, "PASS ALTERNATIVES")
+
+
+def _render_pass_alternatives(args, session: VideoTrackingSession) -> None:
+    locks = session.team_locks()
+    locked_goals = locks.locked_goal_defenders
+    pass_by_frame = session.pass_by_frame
+    freeze_events = session.pass_alternative_events()
+    events_by_frame = {e.frame_idx: e for e in freeze_events}
+    event_frames = sorted(events_by_frame)
+    fps = float(session.fps)
+    width, height = session.width, session.height
+    ramp_frames = max(1, int(round(DEFAULT_SLOWDOWN_RAMP_SECONDS * fps)))
+    reveal_frames = max(4, int(round(DEFAULT_OPTION_REVEAL_SECONDS * fps)))
+    gap_filled = (
+        session.gap_filled_transforms_by_frame if session.kp_by_frame is not None else {}
+    )
+    minimap_transforms = session.minimap_transforms_by_frame
+    pitch_confidence = 0.9
+
+    print(f"PASS_ALTERNATIVES: {len(freeze_events)} freeze events")
+
+    cap, _, _, _ = open_video(args.source_video_path)
+    try:
+        with sv.VideoSink(args.target_video_path, sv.VideoInfo(width, height, fps)) as sink:
+            frame_idx = 0
+            while True:
+                ret, frame = cap.read()
+                if not ret:
+                    break
+                frame_idx += 1
+                if session.max_frames is not None and frame_idx > session.max_frames:
+                    break
+                dets = pass_by_frame.get(frame_idx)
+                if dets is None:
+                    continue
+
+                kps = (session.kp_by_frame or {}).get(frame_idx)
+                radar_h = minimap_transforms.get(frame_idx)
+                lane_h = lane_scoring_transformer_for_frame(
+                    gap_filled, frame_idx, kps, pitch_confidence=pitch_confidence
+                ) or radar_h
+
+                live = _annotate_live(
+                    frame, dets, radar_h=radar_h, locked_goals=locked_goals,
+                )
+                frames_until = next(
+                    (ef - frame_idx for ef in event_frames if ef >= frame_idx), None
+                )
+                hold = (
+                    slowdown_hold_count(frames_until, ramp_frames=ramp_frames)
+                    if frames_until is not None
+                    else 1
+                )
+                for _ in range(hold):
+                    sink.write_frame(live)
+
+                if frame_idx not in events_by_frame:
+                    continue
+
+                event = events_by_frame[frame_idx]
+                n_options = min(3, len(event.options))
+                phases: list[tuple[int, int]] = [(0, reveal_frames)]
+                phases.extend((i, reveal_frames) for i in range(1, n_options + 1))
+                min_freeze = sum(h for _, h in phases)
+                extra_hold = max(
+                    0, int(round(DEFAULT_FREEZE_SECONDS * fps)) - min_freeze
+                )
+                final_extra = max(
+                    4, int(round(DEFAULT_FINAL_OPTION_EXTRA_SECONDS * fps))
+                )
+                if phases:
+                    phases[-1] = (
+                        phases[-1][0],
+                        phases[-1][1] + extra_hold + final_extra,
+                    )
+                for revealed, phase_hold in phases:
+                    for step in range(phase_hold):
+                        progress = (step + 1) / max(phase_hold, 1)
+                        overlay = draw_pass_alternatives_overlay(
+                            frame,
+                            dets,
+                            event,
+                            revealed_options=revealed,
+                            reveal_progress=progress,
+                            transformer=lane_h,
+                            locked_goal_defenders=locked_goals,
+                            metric=True,
+                        )
+                        sink.write_frame(overlay)
+    finally:
+        cap.release()
+    print(f"Wrote {args.target_video_path}")

--- a/examples/soccer/pass_network.py
+++ b/examples/soccer/pass_network.py
@@ -1,10 +1,13 @@
-"""PASS_NETWORK mode: completed passes, collaboration web, and summary end-card."""
+"""PASS_NETWORK mode: completed passes, collaboration web, and summary end-card.
+
+Optional ``--show-predictions`` freezes on detected pass releases and reveals
+ranked open lanes (detect + suggest combined demo).
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import cv2
 import supervision as sv
 
 from sports.annotators.passing import (
@@ -14,13 +17,15 @@ from sports.annotators.passing import (
     draw_carrier_ground_ellipse,
     draw_collaboration_web,
     draw_hud_bar,
+    draw_pass_alternatives_overlay,
     draw_pass_network_end_card,
     draw_pass_network_frame_overlays,
     draw_radar_minimap,
 )
 from sports.common.kinematics import feet_xy
+from sports.common.pass_alternatives import PassEvent
 from sports.common.pass_network import build_pass_network
-from sports.common.possession import find_control_carrier
+from sports.common.possession import carrier_from_tracker_id, find_control_carrier
 from sports.common.tracking import open_video
 from sports.common.video_tracking import VideoTrackingSession, build_video_tracking_session
 
@@ -30,6 +35,18 @@ def run_pass_network(args, session: VideoTrackingSession | None = None) -> None:
     if session is None:
         session = build_video_tracking_session(args, need_homography=True)
     _render_pass_network(args, session)
+
+
+def _prediction_freeze_phases(fps: float, n_options: int) -> list[tuple[int, int]]:
+    reveal_frames = max(4, int(round(0.6 * fps)))
+    phases: list[tuple[int, int]] = [(0, reveal_frames)]
+    phases.extend((i, reveal_frames) for i in range(1, n_options + 1))
+    min_freeze = sum(h for _, h in phases)
+    extra_hold = max(0, int(round(2.5 * fps)) - min_freeze)
+    final_extra = max(4, int(round(1.0 * fps)))
+    if phases:
+        phases[-1] = (phases[-1][0], phases[-1][1] + extra_hold + final_extra)
+    return phases
 
 
 def _render_pass_network(args, session: VideoTrackingSession) -> None:
@@ -45,16 +62,20 @@ def _render_pass_network(args, session: VideoTrackingSession) -> None:
     )
     fps = float(session.fps)
     width, height = session.width, session.height
-    # Short end-card (~2s) with top collaborators (accepted plan recommendation).
     end_hold_frames = max(int(fps * 2), 1)
     minimap_transforms = session.minimap_transforms_by_frame
     gap_filled = (
         session.gap_filled_transforms_by_frame if session.kp_by_frame is not None else {}
     )
+    events_by_frame = {e.frame_idx: e for e in network.passes}
+    show_predictions = bool(getattr(args, "show_predictions", False))
+    freeze_quality_threshold = float(getattr(args, "freeze_quality_threshold", 0.0))
+    scorer = session.pass_scorer if show_predictions else None
 
     print(
         f"PASS_NETWORK: {network.n_passes} passes, {network.n_turnovers} turnovers, "
         f"{len(network.links)} collaboration links"
+        + (" (+ prediction freezes)" if show_predictions else "")
     )
 
     cap, _, _, _ = open_video(args.source_video_path)
@@ -103,6 +124,48 @@ def _render_pass_network(args, session: VideoTrackingSession) -> None:
                     fps,
                     transformer=lane_h,
                 )
+
+                if (
+                    show_predictions
+                    and scorer is not None
+                    and frame_idx in events_by_frame
+                ):
+                    event = events_by_frame[frame_idx]
+                    qs = event.quality_score
+                    if qs is not None and qs >= freeze_quality_threshold:
+                        freeze_carrier = carrier_from_tracker_id(dets, event.passer_tid)
+                        if freeze_carrier is not None:
+                            options = scorer.top_options(
+                                frame_idx, dets, freeze_carrier, k=3
+                            )
+                            if options:
+                                freeze_event = PassEvent(
+                                    frame_idx=frame_idx,
+                                    carrier=freeze_carrier,
+                                    options=options,
+                                    top_score=options[0].score,
+                                )
+                                for revealed, phase_hold in _prediction_freeze_phases(
+                                    fps, min(3, len(options))
+                                ):
+                                    for step in range(phase_hold):
+                                        progress = (step + 1) / max(phase_hold, 1)
+                                        overlay = draw_pass_alternatives_overlay(
+                                            frame,
+                                            dets,
+                                            freeze_event,
+                                            revealed_options=revealed,
+                                            reveal_progress=progress,
+                                            transformer=lane_h,
+                                            locked_goal_defenders=locked_goals,
+                                            metric=True,
+                                            hud_title=(
+                                                "PASS NETWORK  -  detected pass"
+                                                " + open lanes"
+                                            ),
+                                        )
+                                        sink.write_frame(overlay)
+
                 image = draw_radar_minimap(
                     image,
                     dets,

--- a/examples/soccer/pass_network.py
+++ b/examples/soccer/pass_network.py
@@ -131,40 +131,41 @@ def _render_pass_network(args, session: VideoTrackingSession) -> None:
                     and frame_idx in events_by_frame
                 ):
                     event = events_by_frame[frame_idx]
-                    qs = event.quality_score
-                    if qs is not None and qs >= freeze_quality_threshold:
-                        freeze_carrier = carrier_from_tracker_id(dets, event.passer_tid)
-                        if freeze_carrier is not None:
-                            options = scorer.top_options(
-                                frame_idx, dets, freeze_carrier, k=3
+                    freeze_carrier = carrier_from_tracker_id(dets, event.passer_tid)
+                    if freeze_carrier is not None:
+                        options = scorer.top_options(
+                            frame_idx, dets, freeze_carrier, k=3
+                        )
+                        if (
+                            options
+                            and options[0].score >= freeze_quality_threshold
+                        ):
+                            freeze_event = PassEvent(
+                                frame_idx=frame_idx,
+                                carrier=freeze_carrier,
+                                options=options,
+                                top_score=options[0].score,
                             )
-                            if options:
-                                freeze_event = PassEvent(
-                                    frame_idx=frame_idx,
-                                    carrier=freeze_carrier,
-                                    options=options,
-                                    top_score=options[0].score,
-                                )
-                                for revealed, phase_hold in _prediction_freeze_phases(
-                                    fps, min(3, len(options))
-                                ):
-                                    for step in range(phase_hold):
-                                        progress = (step + 1) / max(phase_hold, 1)
-                                        overlay = draw_pass_alternatives_overlay(
-                                            frame,
-                                            dets,
-                                            freeze_event,
-                                            revealed_options=revealed,
-                                            reveal_progress=progress,
-                                            transformer=lane_h,
-                                            locked_goal_defenders=locked_goals,
-                                            metric=True,
-                                            hud_title=(
-                                                "PASS NETWORK  -  detected pass"
-                                                " + open lanes"
-                                            ),
-                                        )
-                                        sink.write_frame(overlay)
+                            for revealed, phase_hold in _prediction_freeze_phases(
+                                fps, min(3, len(options))
+                            ):
+                                for step in range(phase_hold):
+                                    progress = (step + 1) / max(phase_hold, 1)
+                                    overlay = draw_pass_alternatives_overlay(
+                                        frame,
+                                        dets,
+                                        freeze_event,
+                                        revealed_options=revealed,
+                                        reveal_progress=progress,
+                                        transformer=lane_h,
+                                        locked_goal_defenders=locked_goals,
+                                        metric=True,
+                                        hud_title=(
+                                            "PASS NETWORK  -  detected pass"
+                                            " + open lanes"
+                                        ),
+                                    )
+                                    sink.write_frame(overlay)
 
                 image = draw_radar_minimap(
                     image,

--- a/sports/annotators/motion.py
+++ b/sports/annotators/motion.py
@@ -312,8 +312,13 @@ def draw_radar_minimap(
     margin_y: int = 12,
     alpha: float = RADAR_MINIMAP_ALPHA,
     locked_goal_defenders: tuple[int, int] | None = None,
+    decorate_radar=None,
 ) -> np.ndarray:
-    """Overlay a plain translucent radar minimap in the bottom-right corner."""
+    """Overlay a plain translucent radar minimap in the bottom-right corner.
+
+    ``decorate_radar`` is an optional ``Callable[[np.ndarray], np.ndarray]``
+    applied after players are drawn (e.g. pass corridors).
+    """
     if transformer is None:
         return frame
     config = SoccerPitchConfiguration()
@@ -353,6 +358,8 @@ def draw_radar_minimap(
                     scale=minimap_scale,
                     pitch=radar,
                 )
+    if decorate_radar is not None:
+        radar = decorate_radar(radar)
     overlay_minimap(frame, radar, margin_x=margin_x, margin_y=margin_y, alpha=alpha)
     return frame
 

--- a/sports/annotators/passing.py
+++ b/sports/annotators/passing.py
@@ -14,6 +14,7 @@ from sports.annotators.motion import (
 )
 from sports.common.draw import (
     ROBOFLOW_PURPLE_BGR,
+    draw_branding_tag,
     draw_hud_bar,
     draw_score_chip,
     draw_text_shadow,
@@ -555,12 +556,150 @@ def draw_pass_network_end_card(
     return card
 
 
+RANK_LABELS = ("BEST", "2ND", "3RD")
+# Green / gold / orange (BGR) — matches Football AI / fork freeze demos.
 RANK_COLORS_BGR = (
-    (80, 180, 255),   # gold-ish BGR
-    (200, 200, 200),  # silver
-    (180, 130, 70),   # bronze
+    (60, 220, 60),
+    (0, 215, 255),
+    (40, 140, 255),
 )
-RANK_LABELS = ("1st", "2nd", "3rd")
+
+
+def draw_carrier_spotlight(
+    dimmed: np.ndarray,
+    original: np.ndarray,
+    center: tuple[int, int],
+    *,
+    radius: int = 150,
+    strength: float = 0.62,
+) -> np.ndarray:
+    """Keep the ball carrier readable while the rest of the frame is dimmed."""
+    h, w = dimmed.shape[:2]
+    cx, cy = center
+    mask = np.zeros((h, w), dtype=np.float32)
+    cv2.circle(mask, (cx, cy), radius, 1.0, -1, cv2.LINE_AA)
+    mask = cv2.GaussianBlur(mask, (0, 0), sigmaX=radius * 0.38)
+    mask = (mask[..., None] * strength).astype(np.float32)
+    out = dimmed.astype(np.float32) * (1.0 - mask) + original.astype(np.float32) * mask
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def draw_carrier_pulse(
+    frame: np.ndarray,
+    center: tuple[int, int],
+    t: float,
+    *,
+    color_bgr: tuple[int, int, int] = ROBOFLOW_PURPLE_BGR,
+) -> None:
+    """Animated focus rings on the ball carrier."""
+    cx, cy = center
+    for i, base_r in enumerate((22, 36, 52)):
+        phase = (t + i * 0.22) % 1.0
+        wave = 0.5 + 0.5 * np.sin(phase * 2.0 * np.pi)
+        radius = int(base_r * (0.92 + 0.12 * wave))
+        alpha = 0.22 + 0.18 * wave
+        layer = frame.copy()
+        cv2.circle(layer, (cx, cy), radius, color_bgr, 2, cv2.LINE_AA)
+        frame[:] = cv2.addWeighted(layer, alpha, frame, 1.0 - alpha, 0)
+    cv2.circle(frame, (cx, cy), 10, (255, 255, 255), -1, cv2.LINE_AA)
+    cv2.circle(frame, (cx, cy), 14, color_bgr, 2, cv2.LINE_AA)
+
+
+def draw_receiver_highlight(
+    frame: np.ndarray,
+    center: tuple[int, int],
+    rank: int,
+    color_bgr: tuple[int, int, int],
+    *,
+    alpha: float = 1.0,
+) -> None:
+    """Ring at the receiver feet (BEST gets a white outer ring)."""
+    rx, ry = center
+    ring = 20 if rank == 0 else 14
+    layer = frame.copy()
+    cv2.circle(layer, (rx, ry), ring, color_bgr, 3 if rank == 0 else 2, cv2.LINE_AA)
+    if rank == 0:
+        cv2.circle(layer, (rx, ry), ring + 6, (255, 255, 255), 1, cv2.LINE_AA)
+    if alpha >= 0.99:
+        frame[:] = layer
+    else:
+        frame[:] = cv2.addWeighted(layer, alpha, frame, 1.0 - alpha, 0)
+
+
+def pass_line_label_xy(
+    start: tuple[int, int],
+    end: tuple[int, int],
+    *,
+    along: float = 0.42,
+    offset_px: int = 14,
+) -> tuple[int, int]:
+    """Point beside the pass segment for a distance label."""
+    sx, sy = start
+    ex, ey = end
+    px = sx + along * (ex - sx)
+    py = sy + along * (ey - sy)
+    dx, dy = ex - sx, ey - sy
+    norm = float(np.hypot(dx, dy)) or 1.0
+    return (
+        int(px - dy / norm * offset_px),
+        int(py + dx / norm * offset_px),
+    )
+
+
+def draw_pass_analysis_panel(
+    frame: np.ndarray,
+    *,
+    progress: float,
+    revealed: int,
+    total: int = 3,
+    rank_label: str | None = None,
+    rank_color: tuple[int, int, int] | None = None,
+) -> np.ndarray:
+    """Bottom broadcast-style panel for the freeze / reveal sequence."""
+    h, w = frame.shape[:2]
+    panel_h = 78
+    panel_w = min(460, w - 48)
+    px = (w - panel_w) // 2
+    py = h - panel_h - 62
+
+    overlay = frame.copy()
+    cv2.rectangle(overlay, (px, py), (px + panel_w, py + panel_h), (16, 16, 20), -1)
+    cv2.rectangle(overlay, (px, py), (px + panel_w, py + panel_h), (48, 48, 58), 1)
+    cv2.rectangle(overlay, (px, py), (px + panel_w, py + 4), ROBOFLOW_PURPLE_BGR, -1)
+    frame[:] = cv2.addWeighted(overlay, 0.9, frame, 0.1, 0)
+
+    if revealed == 0:
+        title = "PASS ANALYSIS"
+        step = int(progress * 9) % 3
+        dots = "." * (step + 1)
+        subtitle = f"Scanning open lanes{dots}"
+    else:
+        label = rank_label or f"OPTION {revealed}"
+        title = label
+        subtitle = f"Route {revealed} of {total}  |  ranked by lane + distance"
+
+    draw_text_shadow(
+        frame, title, (px + 18, py + 30),
+        font_scale=0.62, color_bgr=rank_color or (255, 255, 255), thickness=2,
+    )
+    draw_text_shadow(
+        frame, subtitle, (px + 18, py + 58),
+        font_scale=0.46, color_bgr=(175, 175, 185), thickness=1,
+    )
+
+    bar_w = panel_w - 36
+    bar_x = px + 18
+    bar_y = py + panel_h - 12
+    cv2.rectangle(frame, (bar_x, bar_y), (bar_x + bar_w, bar_y + 4), (40, 40, 48), -1)
+    fill = int(bar_w * ease_out_cubic(progress if revealed else (0.35 + 0.65 * progress)))
+    cv2.rectangle(
+        frame,
+        (bar_x, bar_y),
+        (bar_x + max(fill, 6), bar_y + 4),
+        rank_color or ROBOFLOW_PURPLE_BGR,
+        -1,
+    )
+    return frame
 
 
 def draw_pass_alternatives_overlay(
@@ -573,8 +712,9 @@ def draw_pass_alternatives_overlay(
     transformer=None,
     locked_goal_defenders: tuple[int, int] | None = None,
     metric: bool = True,
+    hud_title: str = "PASS ALTERNATIVES  -  top open lanes",
 ) -> np.ndarray:
-    """Dimmed freeze frame with ranked pass-lane arrows (reuses shared draw helpers)."""
+    """Dimmed freeze with ranked lanes — spotlight, pulse, chips, analysis panel."""
     dim = (frame.astype(np.float32) * 0.32).astype(np.uint8)
     options = list(event.options)
     visible = options
@@ -587,22 +727,36 @@ def draw_pass_alternatives_overlay(
     feet = feet_xy(dets)
     carrier_xy = feet[event.carrier.index]
     cx, cy = int(carrier_xy[0]), int(carrier_xy[1])
+    dim = draw_carrier_spotlight(dim, frame, (cx, cy))
+
+    n_total = min(3, len(options))
+    progress = float(np.clip(reveal_progress, 0.0, 1.0))
+    phase_revealed = 0 if revealed_options == 0 else (revealed_options or n_total)
+
+    if revealed_options == 0:
+        draw_carrier_pulse(dim, (cx, cy), progress)
+        draw_score_chip(dim, "ON BALL", (cx, cy - 42), bg_bgr=ROBOFLOW_PURPLE_BGR)
+        dim = draw_pass_analysis_panel(
+            dim, progress=progress, revealed=0, total=n_total,
+        )
+        dim = draw_radar_minimap(
+            dim, dets, transformer, locked_goal_defenders=locked_goal_defenders,
+        )
+        return draw_branding_tag(draw_hud_bar(dim, "PASS ALTERNATIVES"))
+
+    draw_carrier_pulse(dim, (cx, cy), min(1.0, progress * 0.35 + 0.65))
     draw_carrier_ground_ellipse(
         dim,
         carrier_xy,
         transformer=transformer,
         color_bgr=CARRIER_SHADOW_BGR,
         radius_m=0.55,
-        alpha=0.55,
+        alpha=0.45,
         filled=True,
         thickness=2,
+        pulse_t=progress,
     )
 
-    if revealed_options == 0:
-        draw_score_chip(dim, "ON BALL", (cx, cy - 42), bg_bgr=ROBOFLOW_PURPLE_BGR)
-        return draw_hud_bar(dim, "PASS ALTERNATIVES")
-
-    progress = float(np.clip(reveal_progress, 0.0, 1.0))
     for rank, option in enumerate(visible):
         color = RANK_COLORS_BGR[min(rank, len(RANK_COLORS_BGR) - 1)]
         recv_xy = feet[option.receiver_index]
@@ -610,6 +764,8 @@ def draw_pass_alternatives_overlay(
         is_new = rank == len(visible) - 1
         alpha = ease_out_cubic(progress) if is_new else 1.0
         draw_glow_arrow(dim, (cx, cy), (rx, ry), color, thickness=5, alpha=alpha)
+        if alpha > 0.2:
+            draw_receiver_highlight(dim, (rx, ry), rank, color, alpha=alpha)
         if alpha < 0.85:
             continue
         midx, midy = (cx + rx) // 2, (cy + ry) // 2
@@ -617,15 +773,29 @@ def draw_pass_alternatives_overlay(
         chip = f"{label}  {option.score:.2f}"
         if metric:
             chip += f"  {option.length:.1f} m"
+        if option.rivals_in_lane:
+            chip += f"  ({option.rivals_in_lane} riv)"
         draw_score_chip(dim, chip, (midx, midy), bg_bgr=color)
+        if metric:
+            lx, ly = pass_line_label_xy((cx, cy), (rx, ry))
+            draw_text_shadow(
+                dim, f"{option.length:.1f} m", (lx - 18, ly - 6),
+                font_scale=0.58, color_bgr=color, thickness=2,
+            )
 
-    dim = draw_radar_minimap(
+    latest_rank = max(len(visible) - 1, 0)
+    dim = draw_pass_analysis_panel(
         dim,
-        dets,
-        transformer,
-        locked_goal_defenders=locked_goal_defenders,
+        progress=progress,
+        revealed=phase_revealed,
+        total=n_total,
+        rank_label=RANK_LABELS[min(latest_rank, len(RANK_LABELS) - 1)] if visible else None,
+        rank_color=RANK_COLORS_BGR[min(latest_rank, len(RANK_COLORS_BGR) - 1)] if visible else None,
     )
-    return draw_hud_bar(dim, "PASS ALTERNATIVES  -  top open lanes")
+    dim = draw_radar_minimap(
+        dim, dets, transformer, locked_goal_defenders=locked_goal_defenders,
+    )
+    return draw_branding_tag(draw_hud_bar(dim, hud_title))
 
 
 # Re-export for runners that already use motion.draw_radar_minimap
@@ -633,12 +803,18 @@ __all__ = [
     "annotate_ball",
     "annotate_pass_players",
     "draw_carrier_ground_ellipse",
+    "draw_carrier_pulse",
+    "draw_carrier_spotlight",
     "draw_collaboration_web",
     "draw_glow_arrow",
     "draw_hud_bar",
     "draw_pass_alternatives_overlay",
+    "draw_pass_analysis_panel",
     "draw_pass_network_end_card",
     "draw_pass_network_frame_overlays",
     "draw_radar_minimap",
+    "draw_receiver_highlight",
     "CARRIER_SHADOW_BGR",
+    "RANK_COLORS_BGR",
+    "RANK_LABELS",
 ]

--- a/sports/annotators/passing.py
+++ b/sports/annotators/passing.py
@@ -555,13 +555,88 @@ def draw_pass_network_end_card(
     return card
 
 
+RANK_COLORS_BGR = (
+    (80, 180, 255),   # gold-ish BGR
+    (200, 200, 200),  # silver
+    (180, 130, 70),   # bronze
+)
+RANK_LABELS = ("1st", "2nd", "3rd")
+
+
+def draw_pass_alternatives_overlay(
+    frame: np.ndarray,
+    dets: sv.Detections,
+    event,
+    *,
+    revealed_options: int | None = None,
+    reveal_progress: float = 1.0,
+    transformer=None,
+    locked_goal_defenders: tuple[int, int] | None = None,
+    metric: bool = True,
+) -> np.ndarray:
+    """Dimmed freeze frame with ranked pass-lane arrows (reuses shared draw helpers)."""
+    dim = (frame.astype(np.float32) * 0.32).astype(np.uint8)
+    options = list(event.options)
+    visible = options
+    if revealed_options is not None:
+        visible = options[: max(0, revealed_options)]
+
+    dim = annotate_pass_players(dim, dets, show_tracker_ids=True)
+    dim = annotate_ball(dim, dets)
+
+    feet = feet_xy(dets)
+    carrier_xy = feet[event.carrier.index]
+    cx, cy = int(carrier_xy[0]), int(carrier_xy[1])
+    draw_carrier_ground_ellipse(
+        dim,
+        carrier_xy,
+        transformer=transformer,
+        color_bgr=CARRIER_SHADOW_BGR,
+        radius_m=0.55,
+        alpha=0.55,
+        filled=True,
+        thickness=2,
+    )
+
+    if revealed_options == 0:
+        draw_score_chip(dim, "ON BALL", (cx, cy - 42), bg_bgr=ROBOFLOW_PURPLE_BGR)
+        return draw_hud_bar(dim, "PASS ALTERNATIVES")
+
+    progress = float(np.clip(reveal_progress, 0.0, 1.0))
+    for rank, option in enumerate(visible):
+        color = RANK_COLORS_BGR[min(rank, len(RANK_COLORS_BGR) - 1)]
+        recv_xy = feet[option.receiver_index]
+        rx, ry = int(recv_xy[0]), int(recv_xy[1])
+        is_new = rank == len(visible) - 1
+        alpha = ease_out_cubic(progress) if is_new else 1.0
+        draw_glow_arrow(dim, (cx, cy), (rx, ry), color, thickness=5, alpha=alpha)
+        if alpha < 0.85:
+            continue
+        midx, midy = (cx + rx) // 2, (cy + ry) // 2
+        label = RANK_LABELS[min(rank, len(RANK_LABELS) - 1)]
+        chip = f"{label}  {option.score:.2f}"
+        if metric:
+            chip += f"  {option.length:.1f} m"
+        draw_score_chip(dim, chip, (midx, midy), bg_bgr=color)
+
+    dim = draw_radar_minimap(
+        dim,
+        dets,
+        transformer,
+        locked_goal_defenders=locked_goal_defenders,
+    )
+    return draw_hud_bar(dim, "PASS ALTERNATIVES  -  top open lanes")
+
+
 # Re-export for runners that already use motion.draw_radar_minimap
 __all__ = [
     "annotate_ball",
     "annotate_pass_players",
     "draw_carrier_ground_ellipse",
     "draw_collaboration_web",
+    "draw_glow_arrow",
     "draw_hud_bar",
+    "draw_pass_alternatives_overlay",
     "draw_pass_network_end_card",
     "draw_pass_network_frame_overlays",
     "draw_radar_minimap",

--- a/sports/annotators/passing.py
+++ b/sports/annotators/passing.py
@@ -7,6 +7,8 @@ import numpy as np
 import supervision as sv
 
 from sports.annotators.motion import (
+    RADAR_MINIMAP_PAD,
+    RADAR_MINIMAP_SCALE,
     annotate_team_ellipses,
     draw_radar_minimap,
     team_color_bgr,
@@ -26,7 +28,8 @@ from sports.common.pass_network import (
     PassNetwork,
     strongest_collaboration_pair,
 )
-from sports.common.pass_pitch import image_to_pitch_m, pitch_circle_to_image
+from sports.common.pass_options import PassOption, PassWeights, remap_lane_debug_to_pitch_cm
+from sports.common.pass_pitch import image_to_pitch_cm, image_to_pitch_m, pitch_circle_to_image, pitch_cm_to_image
 from sports.common.passes import InferredPass, InferredTurnover, passes_for_overlay
 from sports.common.possession import ball_xy
 from sports.common.view import ViewTransformer
@@ -34,6 +37,9 @@ from sports.configs.soccer import BALL_CLASS_ID
 
 TURNOVER_ARROW_BGR = (48, 168, 255)
 CARRIER_SHADOW_BGR = (228, 228, 228)
+_CORRIDOR_ALPHA_VIDEO = 0.38
+_CORRIDOR_ALPHA_RADAR = 0.45
+_BLOCKER_BGR = (40, 40, 255)
 
 _BALL_TRI = sv.TriangleAnnotator(
     color=sv.Color.from_hex("#FFD700"),
@@ -565,6 +571,184 @@ RANK_COLORS_BGR = (
 )
 
 
+def _corridor_image_polygon(
+    corridor_polygon_cm: np.ndarray,
+    transformer: ViewTransformer,
+    frame_shape: tuple[int, ...],
+) -> np.ndarray | None:
+    """Project a pitch corridor (cm) onto image pixels."""
+    img = pitch_cm_to_image(corridor_polygon_cm, transformer)
+    if img is None or len(img) < 3:
+        return None
+    h, w = frame_shape[:2]
+    poly = img.astype(np.int32)
+    if not (
+        (poly[:, 0] >= -w)
+        & (poly[:, 0] <= 2 * w)
+        & (poly[:, 1] >= -h)
+        & (poly[:, 1] <= 2 * h)
+    ).any():
+        return None
+    return poly
+
+
+def draw_pass_corridors_on_frame(
+    frame: np.ndarray,
+    options: list[PassOption],
+    transformer: ViewTransformer,
+    *,
+    display_ranks: list[int] | None = None,
+) -> np.ndarray:
+    """Draw pitch-space pass corridors on the main camera view (H^-1)."""
+    out = frame
+    for idx, option in enumerate(options):
+        rank = display_ranks[idx] if display_ranks is not None else idx
+        debug = option.lane_debug
+        if debug is None:
+            continue
+        poly = _corridor_image_polygon(
+            debug.corridor_polygon_cm, transformer, out.shape
+        )
+        if poly is None:
+            continue
+        color = RANK_COLORS_BGR[min(rank, len(RANK_COLORS_BGR) - 1)]
+        overlay = out.copy()
+        cv2.fillPoly(overlay, [poly], color)
+        out = cv2.addWeighted(
+            overlay, _CORRIDOR_ALPHA_VIDEO, out, 1.0 - _CORRIDOR_ALPHA_VIDEO, 0
+        )
+        cv2.polylines(out, [poly], isClosed=True, color=color, thickness=3)
+    return out
+
+
+def draw_blocking_rivals_on_frame(
+    frame: np.ndarray,
+    options: list[PassOption],
+    *,
+    feet: np.ndarray,
+) -> np.ndarray:
+    """Mark rivals counted inside a corridor — compact red ! at feet."""
+    out = frame
+    drawn: set[int] = set()
+    for option in options:
+        debug = option.lane_debug
+        if debug is None:
+            continue
+        for idx in debug.blocking_rival_indices:
+            if idx in drawn or idx >= len(feet):
+                continue
+            drawn.add(idx)
+            x, y = int(feet[idx, 0]), int(feet[idx, 1])
+            cv2.circle(out, (x, y), 14, _BLOCKER_BGR, -1, cv2.LINE_AA)
+            cv2.putText(
+                out,
+                "!",
+                (x - 7, y + 8),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.55,
+                (255, 255, 255),
+                2,
+                cv2.LINE_AA,
+            )
+    return out
+
+
+def apply_pass_lane_geometry(
+    frame: np.ndarray,
+    options: list[PassOption],
+    transformer: ViewTransformer,
+    feet: np.ndarray,
+) -> np.ndarray:
+    """Shaded corridors + rival blockers under player annotations."""
+    out = draw_pass_corridors_on_frame(frame, options, transformer)
+    return draw_blocking_rivals_on_frame(out, options, feet=feet)
+
+
+def _pitch_cm_to_radar_px(
+    points_cm: np.ndarray,
+    *,
+    scale: float = RADAR_MINIMAP_SCALE,
+    padding: int = RADAR_MINIMAP_PAD,
+) -> np.ndarray:
+    pts = np.asarray(points_cm, dtype=np.float64).reshape(-1, 2)
+    return np.stack(
+        [
+            (pts[:, 0] * scale + padding).astype(np.int32),
+            (pts[:, 1] * scale + padding).astype(np.int32),
+        ],
+        axis=1,
+    )
+
+
+def draw_pass_lanes_on_radar(
+    radar: np.ndarray,
+    options: list[PassOption],
+    pitch_cm: np.ndarray,
+    *,
+    scale: float = RADAR_MINIMAP_SCALE,
+    padding: int = RADAR_MINIMAP_PAD,
+) -> np.ndarray:
+    """Overlay ranked pass corridors and blocking rivals on the minimap."""
+    out = radar.copy()
+    drawn: set[int] = set()
+    for idx, option in enumerate(options):
+        debug = option.lane_debug
+        if debug is None:
+            continue
+        color = RANK_COLORS_BGR[min(idx, len(RANK_COLORS_BGR) - 1)]
+        poly = _pitch_cm_to_radar_px(
+            debug.corridor_polygon_cm, scale=scale, padding=padding
+        )
+        overlay = out.copy()
+        cv2.fillPoly(overlay, [poly], color)
+        out = cv2.addWeighted(
+            overlay, _CORRIDOR_ALPHA_RADAR, out, 1.0 - _CORRIDOR_ALPHA_RADAR, 0
+        )
+        cv2.polylines(out, [poly], isClosed=True, color=color, thickness=2)
+        for bi in debug.blocking_rival_indices:
+            if bi in drawn or bi >= len(pitch_cm):
+                continue
+            drawn.add(bi)
+            pt = _pitch_cm_to_radar_px(
+                pitch_cm[bi : bi + 1], scale=scale, padding=padding
+            )[0]
+            cv2.circle(out, tuple(pt), 12, _BLOCKER_BGR, -1, cv2.LINE_AA)
+            cv2.putText(
+                out,
+                "!",
+                (pt[0] - 5, pt[1] + 5),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (255, 255, 255),
+                2,
+                cv2.LINE_AA,
+            )
+    return out
+
+
+def draw_pass_lane_legend(frame: np.ndarray) -> np.ndarray:
+    """Short legend for corridor overlays."""
+    lines = (
+        "shaded = pass corridor (wider on long passes)",
+        "green / gold / orange = BEST / 2ND / 3RD",
+        "red ! = rival inside corridor",
+    )
+    y = 78
+    for line in lines:
+        cv2.putText(
+            frame,
+            line,
+            (12, y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.42,
+            (230, 230, 230),
+            1,
+            cv2.LINE_AA,
+        )
+        y += 18
+    return frame
+
+
 def draw_carrier_spotlight(
     dimmed: np.ndarray,
     original: np.ndarray,
@@ -712,19 +896,32 @@ def draw_pass_alternatives_overlay(
     transformer=None,
     locked_goal_defenders: tuple[int, int] | None = None,
     metric: bool = True,
+    weights: PassWeights | None = None,
     hud_title: str = "PASS ALTERNATIVES  -  top open lanes",
 ) -> np.ndarray:
-    """Dimmed freeze with ranked lanes — spotlight, pulse, chips, analysis panel."""
+    """Dimmed freeze with ranked corridors + arrows — spotlight, chips, panel."""
     dim = (frame.astype(np.float32) * 0.32).astype(np.uint8)
+    weights = weights or PassWeights.metric()
     options = list(event.options)
+    feet = feet_xy(dets)
+
+    if transformer is not None and options:
+        pitch_cm = image_to_pitch_cm(feet, transformer)
+        if pitch_cm is not None:
+            options = remap_lane_debug_to_pitch_cm(
+                options, event.carrier, pitch_cm, feet, weights=weights,
+            )
+
     visible = options
     if revealed_options is not None:
         visible = options[: max(0, revealed_options)]
 
+    if transformer is not None and visible:
+        dim = apply_pass_lane_geometry(dim, visible, transformer, feet)
+
     dim = annotate_pass_players(dim, dets, show_tracker_ids=True)
     dim = annotate_ball(dim, dets)
 
-    feet = feet_xy(dets)
     carrier_xy = feet[event.carrier.index]
     cx, cy = int(carrier_xy[0]), int(carrier_xy[1])
     dim = draw_carrier_spotlight(dim, frame, (cx, cy))
@@ -732,6 +929,14 @@ def draw_pass_alternatives_overlay(
     n_total = min(3, len(options))
     progress = float(np.clip(reveal_progress, 0.0, 1.0))
     phase_revealed = 0 if revealed_options == 0 else (revealed_options or n_total)
+
+    def _decorate_radar(radar: np.ndarray) -> np.ndarray:
+        if not visible or transformer is None:
+            return radar
+        pitch_cm = image_to_pitch_cm(feet, transformer)
+        if pitch_cm is None:
+            return radar
+        return draw_pass_lanes_on_radar(radar, visible, pitch_cm)
 
     if revealed_options == 0:
         draw_carrier_pulse(dim, (cx, cy), progress)
@@ -775,6 +980,8 @@ def draw_pass_alternatives_overlay(
             chip += f"  {option.length:.1f} m"
         if option.rivals_in_lane:
             chip += f"  ({option.rivals_in_lane} riv)"
+        if option.lane_debug and option.lane_debug.blocking_rival_indices:
+            chip += f"  !{len(option.lane_debug.blocking_rival_indices)}"
         draw_score_chip(dim, chip, (midx, midy), bg_bgr=color)
         if metric:
             lx, ly = pass_line_label_xy((cx, cy), (rx, ry))
@@ -792,8 +999,14 @@ def draw_pass_alternatives_overlay(
         rank_label=RANK_LABELS[min(latest_rank, len(RANK_LABELS) - 1)] if visible else None,
         rank_color=RANK_COLORS_BGR[min(latest_rank, len(RANK_COLORS_BGR) - 1)] if visible else None,
     )
+    if visible and transformer is not None:
+        dim = draw_pass_lane_legend(dim)
     dim = draw_radar_minimap(
-        dim, dets, transformer, locked_goal_defenders=locked_goal_defenders,
+        dim,
+        dets,
+        transformer,
+        locked_goal_defenders=locked_goal_defenders,
+        decorate_radar=_decorate_radar if visible else None,
     )
     return draw_branding_tag(draw_hud_bar(dim, hud_title))
 
@@ -802,6 +1015,8 @@ def draw_pass_alternatives_overlay(
 __all__ = [
     "annotate_ball",
     "annotate_pass_players",
+    "apply_pass_lane_geometry",
+    "draw_blocking_rivals_on_frame",
     "draw_carrier_ground_ellipse",
     "draw_carrier_pulse",
     "draw_carrier_spotlight",
@@ -810,6 +1025,9 @@ __all__ = [
     "draw_hud_bar",
     "draw_pass_alternatives_overlay",
     "draw_pass_analysis_panel",
+    "draw_pass_corridors_on_frame",
+    "draw_pass_lane_legend",
+    "draw_pass_lanes_on_radar",
     "draw_pass_network_end_card",
     "draw_pass_network_frame_overlays",
     "draw_radar_minimap",

--- a/sports/common/draw.py
+++ b/sports/common/draw.py
@@ -88,6 +88,25 @@ def draw_score_chip(
     )
 
 
+def draw_branding_tag(
+    frame: np.ndarray, text: str = "powered by trackers"
+) -> np.ndarray:
+    """Small bottom-left brand tag."""
+    h, w = frame.shape[:2]
+    (tw, th), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, 0.45, 1)
+    x0, y0 = 12, h - 18
+    overlay = frame.copy()
+    cv2.rectangle(
+        overlay, (x0 - 6, y0 - th - 6), (x0 + tw + 8, y0 + 6), (18, 18, 22), -1
+    )
+    frame[:] = cv2.addWeighted(overlay, 0.7, frame, 0.3, 0)
+    draw_text_shadow(
+        frame, text, (x0, y0),
+        font_scale=0.45, color_bgr=ROBOFLOW_PURPLE_BGR, thickness=1,
+    )
+    return frame
+
+
 def make_end_card(
     width: int,
     height: int,

--- a/sports/common/geometry.py
+++ b/sports/common/geometry.py
@@ -175,6 +175,59 @@ def count_lane_blockers_body(
     return int((on_seg & (per_player <= lane_width / 2.0)).sum())
 
 
+def pass_corridor_polygon(
+    a: np.ndarray,
+    b: np.ndarray,
+    half_width: float,
+    *,
+    t_min: float = 0.0,
+    t_max: float = 1.0,
+) -> np.ndarray:
+    """Four corners of the pass corridor quad (same units as ``a`` / ``b``)."""
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    ab = b - a
+    length = float(np.linalg.norm(ab))
+    if length < 1e-9:
+        return np.repeat(a.reshape(1, 2), 4, axis=0)
+    u = ab / length
+    perp = np.array([-u[1], u[0]], dtype=np.float64)
+    start = a + u * (t_min * length)
+    end = a + u * (t_max * length)
+    hw = float(half_width)
+    return np.array(
+        [start + perp * hw, end + perp * hw, end - perp * hw, start - perp * hw],
+        dtype=np.float64,
+    )
+
+
+def lane_blocking_mask_body(
+    feet: np.ndarray,
+    body: np.ndarray,
+    a: np.ndarray,
+    b: np.ndarray,
+    *,
+    t_min: float = 0.0,
+    t_max: float = 1.0,
+    lane_width: float | None = None,
+    player_radius: np.ndarray | None = None,
+) -> np.ndarray:
+    """Boolean mask (len ``feet``) of players blocking the corridor."""
+    if len(feet) == 0:
+        return np.zeros(0, dtype=bool)
+    feet = np.asarray(feet, dtype=np.float64).reshape(-1, 2)
+    body = np.asarray(body, dtype=np.float64).reshape(-1, 2)
+    d_f, t_f = point_to_segment_distance_and_t(feet, a, b)
+    d_b, t_b = point_to_segment_distance_and_t(body, a, b)
+    on_seg = ((t_f >= t_min) & (t_f <= t_max)) | ((t_b >= t_min) & (t_b <= t_max))
+    per_player = np.where(on_seg, np.minimum(d_f, d_b), np.inf)
+    if player_radius is not None:
+        per_player = np.maximum(0.0, per_player - np.asarray(player_radius, dtype=np.float64))
+    if lane_width is None or lane_width <= 0:
+        return on_seg
+    return on_seg & (per_player <= lane_width / 2.0)
+
+
 def unit(vector: np.ndarray) -> np.ndarray:
     """Return the unit vector; zero vector maps to zero."""
     vector = np.asarray(vector, dtype=np.float64)

--- a/sports/common/geometry.py
+++ b/sports/common/geometry.py
@@ -1,8 +1,178 @@
-"""Small vector helpers shared by soccer analytics."""
+"""Small vectorized geometry helpers shared by the demos."""
 
 from __future__ import annotations
 
 import numpy as np
+
+
+def point_to_segment_distance(
+    points: np.ndarray, a: np.ndarray, b: np.ndarray
+) -> np.ndarray:
+    """Shortest distance from each point to the segment ``a -> b``.
+
+    Args:
+        points: ``(N, 2)`` array of points.
+        a: ``(2,)`` segment start.
+        b: ``(2,)`` segment end.
+
+    Returns:
+        ``(N,)`` array of distances.
+    """
+    points = np.asarray(points, dtype=np.float64).reshape(-1, 2)
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    ab = b - a
+    denom = float(ab @ ab)
+    if denom < 1e-9:
+        return np.linalg.norm(points - a, axis=1)
+    t = ((points - a) @ ab) / denom
+    t = np.clip(t, 0.0, 1.0)
+    proj = a + t[:, None] * ab
+    return np.linalg.norm(points - proj, axis=1)
+
+
+def point_to_segment_distance_and_t(
+    points: np.ndarray, a: np.ndarray, b: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Distance to segment ``a -> b`` and projection parameter ``t`` (0=start, 1=end)."""
+    points = np.asarray(points, dtype=np.float64).reshape(-1, 2)
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    ab = b - a
+    denom = float(ab @ ab)
+    if denom < 1e-9:
+        t = np.zeros(len(points), dtype=np.float64)
+        return np.linalg.norm(points - a, axis=1), t
+    t = ((points - a) @ ab) / denom
+    t_clip = np.clip(t, 0.0, 1.0)
+    proj = a + t_clip[:, None] * ab
+    return np.linalg.norm(points - proj, axis=1), t
+
+
+def _pass_corridor_mask(
+    dists: np.ndarray,
+    t: np.ndarray,
+    *,
+    t_min: float,
+    t_max: float,
+    lane_width: float | None,
+) -> np.ndarray:
+    """Points that can intercept: on the segment and within ``lane_width`` (full width)."""
+    on_segment = (t >= t_min) & (t <= t_max)
+    if lane_width is None or lane_width <= 0:
+        return on_segment
+    return on_segment & (dists <= lane_width / 2.0)
+
+
+def lane_segment_clearance(
+    points: np.ndarray,
+    a: np.ndarray,
+    b: np.ndarray,
+    *,
+    t_min: float = 0.0,
+    t_max: float = 1.0,
+    lane_width: float | None = None,
+) -> tuple[float, float]:
+    """Min perpendicular distance among intercept threats vs min over all points.
+
+    *Lane* = projection ``t`` in ``[t_min, t_max]``. When ``lane_width`` is set (e.g.
+    1 m in metric scoring), only rivals within half that distance of the pass line
+    count as able to intercept.
+    """
+    if len(points) == 0:
+        return float("inf"), float("inf")
+    dists, t = point_to_segment_distance_and_t(points, a, b)
+    segment_min = float(dists.min())
+    in_corridor = _pass_corridor_mask(
+        dists, t, t_min=t_min, t_max=t_max, lane_width=lane_width
+    )
+    if not in_corridor.any():
+        return float("inf"), segment_min
+    return float(dists[in_corridor].min()), segment_min
+
+
+def count_lane_blockers(
+    points: np.ndarray,
+    a: np.ndarray,
+    b: np.ndarray,
+    *,
+    t_min: float = 0.0,
+    t_max: float = 1.0,
+    lane_width: float | None = None,
+) -> int:
+    """Count points in the pass corridor (segment projection + optional width)."""
+    if len(points) == 0:
+        return 0
+    dists, t = point_to_segment_distance_and_t(points, a, b)
+    return int(
+        _pass_corridor_mask(
+            dists, t, t_min=t_min, t_max=t_max, lane_width=lane_width
+        ).sum()
+    )
+
+
+def lane_segment_clearance_body(
+    feet: np.ndarray,
+    body: np.ndarray,
+    a: np.ndarray,
+    b: np.ndarray,
+    *,
+    t_min: float = 0.0,
+    t_max: float = 1.0,
+    lane_width: float | None = None,
+    player_radius: np.ndarray | None = None,
+) -> tuple[float, float]:
+    """Lane clearance using min(feet, body) distance per player on the segment.
+
+    *player_radius* shrinks effective distance (bbox half-width) so a player whose
+    body crosses the pass line counts even when feet are slightly off the segment.
+    """
+    if len(feet) == 0:
+        return float("inf"), float("inf")
+    feet = np.asarray(feet, dtype=np.float64).reshape(-1, 2)
+    body = np.asarray(body, dtype=np.float64).reshape(-1, 2)
+    d_f, t_f = point_to_segment_distance_and_t(feet, a, b)
+    d_b, t_b = point_to_segment_distance_and_t(body, a, b)
+    on_seg = ((t_f >= t_min) & (t_f <= t_max)) | ((t_b >= t_min) & (t_b <= t_max))
+    segment_min = float(min(d_f.min(), d_b.min()))
+    if not on_seg.any():
+        return segment_min, segment_min
+    per_player = np.where(on_seg, np.minimum(d_f, d_b), np.inf)
+    if player_radius is not None:
+        per_player = np.maximum(0.0, per_player - np.asarray(player_radius, dtype=np.float64))
+    if lane_width is None or lane_width <= 0:
+        threats = per_player[on_seg]
+    else:
+        threats = per_player[on_seg & (per_player <= lane_width / 2.0)]
+    if len(threats) == 0:
+        return float("inf"), segment_min
+    return float(np.min(threats)), segment_min
+
+
+def count_lane_blockers_body(
+    feet: np.ndarray,
+    body: np.ndarray,
+    a: np.ndarray,
+    b: np.ndarray,
+    *,
+    t_min: float = 0.0,
+    t_max: float = 1.0,
+    lane_width: float | None = None,
+    player_radius: np.ndarray | None = None,
+) -> int:
+    if len(feet) == 0:
+        return 0
+    feet = np.asarray(feet, dtype=np.float64).reshape(-1, 2)
+    body = np.asarray(body, dtype=np.float64).reshape(-1, 2)
+    d_f, t_f = point_to_segment_distance_and_t(feet, a, b)
+    d_b, t_b = point_to_segment_distance_and_t(body, a, b)
+    on_seg = ((t_f >= t_min) & (t_f <= t_max)) | ((t_b >= t_min) & (t_b <= t_max))
+    per_player = np.where(on_seg, np.minimum(d_f, d_b), np.inf)
+    if player_radius is not None:
+        per_player = np.maximum(0.0, per_player - np.asarray(player_radius, dtype=np.float64))
+    if lane_width is None or lane_width <= 0:
+        return int(on_seg.sum())
+    return int((on_seg & (per_player <= lane_width / 2.0)).sum())
 
 
 def unit(vector: np.ndarray) -> np.ndarray:

--- a/sports/common/kinematics.py
+++ b/sports/common/kinematics.py
@@ -5,6 +5,7 @@ import numpy as np
 import supervision as sv
 from trackers.utils.state_representations import XCYCWHStateEstimator, XYXYStateEstimator
 
+from sports.common.geometry import unit
 from sports.configs.soccer import GOALKEEPER_CLASS_ID, PLAYER_CLASS_ID
 
 DEFAULT_MIN_SPEED_PX = 0.5
@@ -76,6 +77,38 @@ def kalman_velocity_arrays(
         kf_vx[i] = float(vel[0])
         kf_vy[i] = float(vel[1])
     return kf_vx, kf_vy
+
+
+def carrier_kalman_direction(
+    detections: sv.Detections,
+    carrier_index: int,
+    *,
+    transformer=None,
+    min_speed: float = DEFAULT_MIN_SPEED_PX,
+) -> np.ndarray | None:
+    """Unit movement direction for the ball carrier from Kalman velocity."""
+    if detections.data is None:
+        return None
+    kf_vx = detections.data.get("kf_vx")
+    kf_vy = detections.data.get("kf_vy")
+    if kf_vx is None or kf_vy is None:
+        return None
+    vx, vy = float(kf_vx[carrier_index]), float(kf_vy[carrier_index])
+    if not np.isfinite(vx) or not np.isfinite(vy):
+        return None
+    speed = float(np.hypot(vx, vy))
+    if speed < min_speed:
+        return None
+    vel_img = np.array([vx, vy], dtype=np.float64)
+    if transformer is None:
+        return unit(vel_img)
+    from sports.common.homography import image_displacement_to_pitch_m
+
+    feet = feet_xy(detections)[carrier_index]
+    delta = image_displacement_to_pitch_m(feet, vel_img, transformer)
+    if delta is None or float(np.linalg.norm(delta)) < 1e-6:
+        return unit(vel_img)
+    return unit(delta)
 
 
 def merge_kalman_velocity(

--- a/sports/common/pass_alternatives.py
+++ b/sports/common/pass_alternatives.py
@@ -1,0 +1,296 @@
+"""Freeze-moment planning for PASS_ALTERNATIVES."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import supervision as sv
+
+from sports.common.pass_options import PassOption, PassQualityScorer, PassWeights
+from sports.common.pass_pitch import lane_scoring_transformer_for_frame
+from sports.common.possession import (
+    BallPositionHistory,
+    Carrier,
+    ball_xy,
+    find_control_carrier,
+)
+
+__all__ = [
+    "PassEvent",
+    "plan_pass_events",
+    "DEFAULT_SLOWDOWN_RAMP_SECONDS",
+    "DEFAULT_OPTION_REVEAL_SECONDS",
+    "DEFAULT_FREEZE_SECONDS",
+    "DEFAULT_FINAL_OPTION_EXTRA_SECONDS",
+    "MAX_RAMP_HOLD",
+    "slowdown_hold_count",
+]
+
+
+@dataclass(frozen=True)
+class PassEvent:
+    frame_idx: int
+    carrier: Carrier
+    options: list[PassOption]
+    top_score: float
+
+
+MAX_RAMP_HOLD = 6
+DEFAULT_SLOWDOWN_RAMP_SECONDS = 0.72
+DEFAULT_OPTION_REVEAL_SECONDS = 0.6
+DEFAULT_FREEZE_SECONDS = 2.5
+DEFAULT_FINAL_OPTION_EXTRA_SECONDS = 1.0
+
+
+def _freeze_moment_score(
+    pass_top: float,
+    carrier: Carrier,
+    *,
+    ball_speed: float | None,
+    weights: PassWeights,
+    metric: bool,
+) -> float | None:
+    if weights.use_ball_control_gate and ball_speed is not None:
+        if metric:
+            if ball_speed >= weights.ball_speed_skip_m:
+                return None
+            ref, cap = weights.ball_speed_ref_m, weights.ball_speed_max_m
+            tight_ref = weights.carrier_tight_ref_m
+        else:
+            if ball_speed >= weights.ball_speed_skip_px_s:
+                return None
+            ref, cap = weights.ball_speed_ref_px_s, weights.ball_speed_max_px_s
+            tight_ref = weights.carrier_tight_ref_px
+
+        score = pass_top
+        if ball_speed <= ref:
+            score += 0.05
+        elif ball_speed < cap:
+            t = (ball_speed - ref) / (cap - ref)
+            score -= weights.ball_speed_penalty * t
+        else:
+            score -= weights.ball_speed_penalty
+
+        if carrier.distance < tight_ref:
+            score += weights.carrier_tight_bonus * (
+                1.0 - carrier.distance / tight_ref
+            )
+        return score
+
+    score = pass_top
+    tight_ref = (
+        weights.carrier_tight_ref_m if metric else weights.carrier_tight_ref_px
+    )
+    if carrier.distance < tight_ref:
+        score += weights.carrier_tight_bonus * (1.0 - carrier.distance / tight_ref)
+    return score
+
+
+def _resolve_freeze_frame_earlier(
+    event: PassEvent,
+    by_frame: dict[int, PassEvent],
+    *,
+    weights: PassWeights,
+    metric: bool,
+    instant_speed_by_frame: dict[int, float],
+) -> PassEvent:
+    if not weights.freeze_nudge_earlier:
+        return event
+    slack = weights.freeze_nudge_score_slack
+    eps = (
+        weights.freeze_separation_eps_m
+        if metric
+        else weights.freeze_separation_eps_px
+    )
+    best = event
+
+    while True:
+        prev = by_frame.get(best.frame_idx - 1)
+        if prev is None or prev.top_score < best.top_score - slack:
+            break
+        separating = best.carrier.distance > prev.carrier.distance + eps
+        instant = instant_speed_by_frame.get(best.frame_idx)
+        fast_ball = instant is not None and (
+            (metric and instant >= weights.freeze_release_ball_speed_skip_m)
+            or (not metric and instant >= weights.freeze_release_ball_speed_skip_px_s)
+        )
+        if not (separating or fast_ball):
+            break
+        best = prev
+
+    prev = by_frame.get(best.frame_idx - 1)
+    if (
+        prev is not None
+        and best.top_score > prev.top_score
+        and prev.top_score >= best.top_score - slack
+    ):
+        best = prev
+
+    return best
+
+
+def _apply_freeze_frame_nudges(
+    candidates: list[PassEvent],
+    *,
+    weights: PassWeights,
+    metric: bool,
+    instant_speed_by_frame: dict[int, float],
+) -> list[PassEvent]:
+    by_frame = {e.frame_idx: e for e in candidates}
+    resolved: dict[int, PassEvent] = {}
+    for event in candidates:
+        nudged = _resolve_freeze_frame_earlier(
+            event,
+            by_frame,
+            weights=weights,
+            metric=metric,
+            instant_speed_by_frame=instant_speed_by_frame,
+        )
+        prev = resolved.get(nudged.frame_idx)
+        if prev is None or nudged.top_score > prev.top_score:
+            resolved[nudged.frame_idx] = nudged
+    return sorted(resolved.values(), key=lambda e: e.frame_idx)
+
+
+def _select_pass_moments(
+    candidates: list[PassEvent],
+    *,
+    weights: PassWeights,
+    min_gap_frames: int,
+    max_events: int | None,
+) -> list[PassEvent]:
+    if not candidates:
+        return []
+
+    by_frame = sorted(candidates, key=lambda e: e.frame_idx)
+    score_at = {e.frame_idx: e.top_score for e in by_frame}
+    half = weights.freeze_local_peak_half_window
+
+    peaks: list[PassEvent] = []
+    for event in by_frame:
+        if event.top_score < weights.freeze_min_pick_score:
+            continue
+        if event.options[0].score < weights.freeze_min_pass_score:
+            continue
+        if weights.freeze_detect_local_peaks:
+            f = event.frame_idx
+            neighbor_scores = [
+                score_at.get(f + d, -1.0)
+                for d in range(-half, half + 1)
+                if d != 0 and (f + d) in score_at
+            ]
+            if neighbor_scores and event.top_score <= max(neighbor_scores):
+                continue
+        peaks.append(event)
+
+    peaks.sort(key=lambda e: e.top_score, reverse=True)
+    chosen: list[PassEvent] = []
+    for event in peaks:
+        if all(abs(event.frame_idx - c.frame_idx) >= min_gap_frames for c in chosen):
+            chosen.append(event)
+        if max_events is not None and len(chosen) >= max_events:
+            break
+    chosen.sort(key=lambda e: e.frame_idx)
+    return chosen
+
+
+def slowdown_hold_count(
+    frames_until_event: int,
+    *,
+    ramp_frames: int,
+    max_extra_holds: int = MAX_RAMP_HOLD,
+) -> int:
+    """Repeat count for live frames as playback eases into a freeze."""
+    if frames_until_event <= 0 or frames_until_event > ramp_frames:
+        return 1
+    t = 1.0 - frames_until_event / ramp_frames
+    return 1 + int((t * t) * max(0, max_extra_holds - 1))
+
+
+def plan_pass_events(
+    pass_frames: list[tuple[int, sv.Detections]],
+    *,
+    fps: float,
+    frame_transforms: dict[int, Any | None],
+    keypoints_by_frame: dict[int, Any | None] | None = None,
+    scorer: PassQualityScorer | None = None,
+    weights: PassWeights | None = None,
+    max_events: int | None = None,
+    min_gap_frames: int = 90,
+    pitch_confidence: float = 0.9,
+    min_frame_idx: int = 30,
+) -> list[PassEvent]:
+    """Detect cinematic pass freeze moments from pass-ready frames.
+
+    Lane scoring goes through :class:`PassQualityScorer` for ranked alternatives.
+    """
+    weights = weights or PassWeights.metric()
+    keypoints_by_frame = keypoints_by_frame or {}
+    if scorer is None:
+        scorer = PassQualityScorer(
+            weights=weights,
+            transformers=frame_transforms,
+            keypoints_by_frame=keypoints_by_frame,
+            pitch_confidence=pitch_confidence,
+        )
+    max_px = weights.freeze_carrier_max_distance_px
+    max_m = weights.freeze_carrier_max_distance_m
+    require_both = weights.freeze_require_both_spaces
+
+    ball_history = BallPositionHistory()
+    candidates: list[PassEvent] = []
+    instant_speed_by_frame: dict[int, float] = {}
+
+    for frame_idx, dets in pass_frames:
+        kps = keypoints_by_frame.get(frame_idx)
+        transformer = lane_scoring_transformer_for_frame(
+            frame_transforms, frame_idx, kps, pitch_confidence=pitch_confidence
+        )
+        ball_history.record(frame_idx, ball_xy(dets))
+
+        carrier = find_control_carrier(
+            dets,
+            max_distance_px=max_px,
+            transformer=transformer,
+            max_distance_m=max_m,
+            require_both_spaces=require_both and transformer is not None,
+        )
+        if carrier is None or frame_idx < min_frame_idx:
+            continue
+        options = scorer.top_options(frame_idx, dets, carrier, k=3)
+        if len(options) < 2:
+            continue
+        top = options[0]
+        if top.length < weights.min_length or top.length > weights.max_length:
+            continue
+        ball_speed = ball_history.speed(
+            frame_idx,
+            lookback_frames=weights.ball_speed_lookback_frames,
+            fps=fps,
+            transformer=transformer,
+        )
+        pick_score = _freeze_moment_score(
+            top.score, carrier, ball_speed=ball_speed, weights=weights, metric=True
+        )
+        if pick_score is None:
+            continue
+        instant = ball_history.speed(
+            frame_idx, lookback_frames=1, fps=fps, transformer=transformer
+        )
+        if instant is not None:
+            instant_speed_by_frame[frame_idx] = instant
+        candidates.append(PassEvent(frame_idx, carrier, options, pick_score))
+
+    candidates = _apply_freeze_frame_nudges(
+        candidates,
+        weights=weights,
+        metric=True,
+        instant_speed_by_frame=instant_speed_by_frame,
+    )
+    return _select_pass_moments(
+        candidates,
+        weights=weights,
+        min_gap_frames=min_gap_frames,
+        max_events=max_events,
+    )

--- a/sports/common/pass_options.py
+++ b/sports/common/pass_options.py
@@ -19,7 +19,7 @@ input coordinates: pixels for v1, meters for v2), then combined with weights.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import numpy as np
 import supervision as sv
@@ -27,8 +27,10 @@ import supervision as sv
 from sports.common.geometry import (
     count_lane_blockers,
     count_lane_blockers_body,
+    lane_blocking_mask_body,
     lane_segment_clearance,
     lane_segment_clearance_body,
+    pass_corridor_polygon,
     point_to_segment_distance,
     unit,
 )
@@ -144,6 +146,15 @@ class PassWeights:
 
 
 @dataclass(frozen=True)
+class PassLaneDebug:
+    """Pitch-radar debug: corridor quad (cm) and detection indices of blockers."""
+
+    corridor_polygon_cm: np.ndarray
+    blocking_rival_indices: tuple[int, ...]
+    blocking_teammate_indices: tuple[int, ...]
+
+
+@dataclass(frozen=True)
 class PassOption:
     receiver_index: int
     receiver_xy: np.ndarray
@@ -159,6 +170,7 @@ class PassOption:
     motion_alignment: float  # cos(pass, run); 0 if run unknown
     receiver_space: float  # raw distance, receiver to nearest opponent
     length: float
+    lane_debug: PassLaneDebug | None = None
 
 
 def _rival_lane_width_steps(
@@ -209,6 +221,140 @@ def _open_ref_for_lane(weights: PassWeights, lane_width: float | None) -> float:
     if weights.lane_in_image_space and lane_width is not None and lane_width > 0:
         return lane_width
     return weights.open_ref
+
+
+def _half_width_cm(
+    weights: PassWeights,
+    lane_width: float | None,
+    *,
+    pass_length_m: float,
+    pass_length_px: float,
+    use_image_lane: bool,
+) -> float:
+    """Corridor half-width in pitch cm for radar / video overlays."""
+    if lane_width is None or lane_width <= 0:
+        return 50.0
+    if use_image_lane and pass_length_px > 1e-3 and pass_length_m > 1e-3:
+        cm_per_px = pass_length_m * 100.0 / pass_length_px
+        return (lane_width / 2.0) * cm_per_px
+    return (lane_width / 2.0) * 100.0
+
+
+def _build_lane_debug(
+    *,
+    pitch_cm: np.ndarray,
+    carrier_index: int,
+    receiver_index: int,
+    opponents: np.ndarray,
+    teammates_block: np.ndarray,
+    lane_opp_feet: np.ndarray,
+    lane_opp_body: np.ndarray,
+    lane_team_feet: np.ndarray,
+    lane_carrier: np.ndarray,
+    lane_receiver: np.ndarray,
+    lane_kw: dict,
+    team_lane_kw: dict,
+    use_body: bool,
+    opp_radius: np.ndarray | None,
+    half_width_cm: float,
+) -> PassLaneDebug:
+    opp_global = np.flatnonzero(opponents)
+    team_global = np.flatnonzero(teammates_block)
+    if use_body and len(lane_opp_feet):
+        rival_mask = lane_blocking_mask_body(
+            lane_opp_feet,
+            lane_opp_body,
+            lane_carrier,
+            lane_receiver,
+            player_radius=opp_radius,
+            **lane_kw,
+        )
+        team_mask = lane_blocking_mask_body(
+            lane_team_feet,
+            lane_team_feet,
+            lane_carrier,
+            lane_receiver,
+            player_radius=None,
+            **team_lane_kw,
+        )
+    else:
+        rival_mask = lane_blocking_mask_body(
+            lane_opp_feet,
+            lane_opp_feet,
+            lane_carrier,
+            lane_receiver,
+            **lane_kw,
+        )
+        team_mask = lane_blocking_mask_body(
+            lane_team_feet,
+            lane_team_feet,
+            lane_carrier,
+            lane_receiver,
+            **team_lane_kw,
+        )
+    poly = pass_corridor_polygon(
+        pitch_cm[carrier_index],
+        pitch_cm[receiver_index],
+        half_width_cm,
+        t_min=lane_kw["t_min"],
+        t_max=lane_kw["t_max"],
+    )
+    return PassLaneDebug(
+        corridor_polygon_cm=poly,
+        blocking_rival_indices=tuple(
+            int(opp_global[i]) for i in np.flatnonzero(rival_mask)
+        ),
+        blocking_teammate_indices=tuple(
+            int(team_global[i]) for i in np.flatnonzero(team_mask)
+        ),
+    )
+
+
+def remap_lane_debug_to_pitch_cm(
+    options: list[PassOption],
+    carrier: Carrier,
+    pitch_cm: np.ndarray,
+    feet_img: np.ndarray,
+    *,
+    weights: PassWeights | None = None,
+) -> list[PassOption]:
+    """Rebuild corridor quads in another pitch-cm frame (e.g. sports radar H)."""
+    weights = weights or PassWeights.metric()
+    ci = carrier.index
+    remapped: list[PassOption] = []
+    for opt in options:
+        ri = opt.receiver_index
+        if ci >= len(pitch_cm) or ri >= len(pitch_cm):
+            remapped.append(opt)
+            continue
+        delta_cm = pitch_cm[ri] - pitch_cm[ci]
+        length_m = float(np.linalg.norm(delta_cm)) / 100.0
+        pass_len_px = float(np.linalg.norm(feet_img[ri] - feet_img[ci]))
+        lane_w = _lane_width_for_pass(
+            weights, pass_length=length_m, pass_length_px=pass_len_px
+        )
+        half_cm = _half_width_cm(
+            weights,
+            lane_w,
+            pass_length_m=length_m,
+            pass_length_px=pass_len_px,
+            use_image_lane=weights.lane_in_image_space,
+        )
+        poly = pass_corridor_polygon(
+            pitch_cm[ci],
+            pitch_cm[ri],
+            half_cm,
+            t_min=weights.lane_t_min,
+            t_max=weights.lane_t_max,
+        )
+        prev = opt.lane_debug
+        debug = PassLaneDebug(
+            corridor_polygon_cm=poly,
+            blocking_rival_indices=prev.blocking_rival_indices if prev else (),
+            blocking_teammate_indices=prev.blocking_teammate_indices if prev else (),
+        )
+        remapped.append(replace(opt, lane_debug=debug))
+    return remapped
 
 
 def _backward_motion_penalty_from_align(
@@ -282,6 +428,7 @@ def score_pass_options(
     attack_dir: np.ndarray | None = None,
     positions: np.ndarray | None = None,
     carrier_motion_dir: np.ndarray | None = None,
+    pitch_cm: np.ndarray | None = None,
     body_pitch_m: np.ndarray | None = None,
 ) -> list[PassOption]:
     """Rank every teammate as a passing option (best first).
@@ -289,6 +436,7 @@ def score_pass_options(
     Pass *positions* (e.g. pitch coordinates in meters) to score in metric space
     instead of image pixels. *carrier_motion_dir* is the unit run vector from recent
     Kalman filter velocity (same coordinate system as *positions*).
+    When *pitch_cm* is set, each option also carries corridor geometry for overlays.
     """
     pmask = player_mask(detections)
     feet_img = feet_xy(detections)
@@ -447,6 +595,33 @@ def score_pass_options(
         if length < weights.min_length or length > weights.max_length:
             continue
 
+        lane_debug = None
+        if pitch_cm is not None and weights.use_lane_openness:
+            half_cm = _half_width_cm(
+                weights,
+                lane_w,
+                pass_length_m=length,
+                pass_length_px=pass_len_px,
+                use_image_lane=use_image_lane,
+            )
+            lane_debug = _build_lane_debug(
+                pitch_cm=pitch_cm,
+                carrier_index=carrier.index,
+                receiver_index=int(idx),
+                opponents=opponents,
+                teammates_block=blockers,
+                lane_opp_feet=lane_opp_feet,
+                lane_opp_body=lane_opp_body,
+                lane_team_feet=team_xy if len(team_xy) else np.zeros((0, 2)),
+                lane_carrier=lane_carrier,
+                lane_receiver=lane_receiver,
+                lane_kw=lane_kw,
+                team_lane_kw=team_lane_kw,
+                use_body=weights.lane_use_body_center,
+                opp_radius=opp_radius,
+                half_width_cm=half_cm,
+            )
+
         options.append(
             PassOption(
                 receiver_index=int(idx),
@@ -463,6 +638,7 @@ def score_pass_options(
                 motion_alignment=motion_align,
                 receiver_space=receiver_space,
                 length=length,
+                lane_debug=lane_debug,
             )
         )
 

--- a/sports/common/pass_options.py
+++ b/sports/common/pass_options.py
@@ -1,0 +1,579 @@
+"""Score teammate passing lanes for a ball carrier.
+
+Each candidate lane (carrier -> teammate) is scored on three football-sense axes:
+
+* **openness** - nearest **rival** in the pass corridor (``lane_width``, strict; widens
+  in fixed length tiers on long passes, not proportional to distance).
+* **teammate lane** - optional light penalty if a teammate blocks the corridor (narrower
+  width than rivals; they can let the ball through so we only ding obvious obstacles).
+* **forward progress** - gain toward the attacking direction.
+* **carrier motion** - passes behind the carrier's Kalman-predicted run direction are penalized.
+* **backward attack** - passes toward own goal (negative forward gain) are penalized when
+  the carrier is running forward (optional gate).
+* **receiver space** - how much room the receiver has from the nearest opponent.
+
+A short-range/very-long-range penalty keeps the suggestions realistic. Scores are
+normalized to ``[0, 1]`` against tunable reference distances (in the same units as the
+input coordinates: pixels for v1, meters for v2), then combined with weights.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import supervision as sv
+
+from sports.common.geometry import (
+    count_lane_blockers,
+    count_lane_blockers_body,
+    lane_segment_clearance,
+    lane_segment_clearance_body,
+    point_to_segment_distance,
+    unit,
+)
+from sports.common.kinematics import carrier_kalman_direction, feet_xy, player_mask
+from sports.common.pass_pitch import (
+    attack_direction,
+    image_to_pitch_cm,
+    image_to_pitch_m,
+    lane_scoring_transformer_for_frame,
+)
+from sports.common.possession import (
+    CONTROL_MAX_DISTANCE_M,
+    CONTROL_MAX_DISTANCE_PX,
+    Carrier,
+    bbox_center_xy,
+)
+
+
+@dataclass(frozen=True)
+class PassWeights:
+    openness: float = 0.45
+    forward: float = 0.30
+    space: float = 0.25
+    # reference scales for normalization (pixels for v1)
+    open_ref: float = 120.0
+    space_ref: float = 120.0
+    forward_ref: float = 600.0
+    min_length: float = 60.0
+    max_length: float = 1100.0
+    use_lane_openness: bool = True
+    lane_t_min: float = 0.0
+    lane_t_max: float = 1.0
+    lane_width: float | None = None  # base rival corridor width in m (pitch) or px (image)
+    lane_width_mid_threshold_m: float = 18.0  # stepped boosts below (metric only)
+    lane_width_long_threshold_m: float = 28.0
+    lane_width_mid_boost_m: float = 0.75
+    lane_width_long_boost_m: float = 1.5
+    lane_width_max_m: float = 4.5
+    lane_in_image_space: bool = False  # metric default: pitch/radar corridor (meters)
+    lane_use_body_center: bool = True  # min(feet, bbox center) for rival lane distance
+    teammate_lane_width: float | None = None  # None -> 0.5 * lane_width when lane_width set
+    teammate_open_ref: float | None = None  # clearance scale for teammate penalty; None -> open_ref
+    teammate_lane_penalty: float = 0.0  # max score deduction when a teammate blocks (0 = off)
+    openness_rivals_only: bool = True  # openness field = rivals only; teammate uses penalty
+    use_carrier_motion: bool = True
+    motion_lookback_frames: int = 5
+    motion_min_displacement_px: float = 5.0
+    motion_min_displacement_m: float = 0.35
+    backward_penalty: float = 0.22
+    backward_cos_threshold: float = -0.15  # pass vs run; below => backward
+    backward_attack_penalty: float = 0.18
+    backward_attack_only_when_running_forward: bool = True
+    backward_attack_motion_cos_threshold: float = 0.15  # run vs attack; above => gate on
+    # Freeze-moment selection (plan_events): same in-control gate as pass detection
+    freeze_carrier_max_distance_m: float = CONTROL_MAX_DISTANCE_M
+    freeze_carrier_max_distance_px: float = CONTROL_MAX_DISTANCE_PX
+    freeze_require_both_spaces: bool = False
+    freeze_nudge_earlier: bool = True
+    freeze_nudge_score_slack: float = 0.08
+    freeze_separation_eps_m: float = 0.03
+    freeze_separation_eps_px: float = 2.5
+    freeze_release_ball_speed_skip_m: float = 2.5
+    freeze_release_ball_speed_skip_px_s: float = 120.0
+    use_ball_control_gate: bool = True
+    ball_speed_lookback_frames: int = 4
+    ball_speed_ref_m: float = 1.5
+    ball_speed_max_m: float = 4.5
+    ball_speed_skip_m: float = 8.0
+    ball_speed_penalty: float = 0.40
+    ball_speed_ref_px_s: float = 90.0
+    ball_speed_max_px_s: float = 320.0
+    ball_speed_skip_px_s: float = 500.0
+    carrier_tight_ref_m: float = 0.45
+    carrier_tight_ref_px: float = 40.0
+    carrier_tight_bonus: float = 0.12
+    # Good-pass-moment detection (plan_events): threshold + local score peaks
+    freeze_min_pick_score: float = 0.68
+    freeze_min_pass_score: float = 0.48
+    freeze_local_peak_half_window: int = 12
+    freeze_detect_local_peaks: bool = True
+
+    @classmethod
+    def metric(cls) -> PassWeights:
+        """Reference distances in pitch meters (homography-calibrated scoring).
+
+        Tuned so lane scores spread across [0, 1]: a *very* open lane keeps the
+        nearest opponent ~8 m off the pass line, a tight one ~1-2 m; a strong
+        forward pass advances ~25 m toward the opponent goal.
+        """
+        return cls(
+            open_ref=8.0,
+            space_ref=8.0,
+            forward_ref=25.0,
+            min_length=2.0,
+            max_length=45.0,
+            lane_width=2.5,
+            lane_in_image_space=False,
+            lane_use_body_center=True,
+            teammate_lane_width=2.0,
+            teammate_open_ref=0.5,
+            teammate_lane_penalty=0.10,
+            use_carrier_motion=True,
+            motion_min_displacement_m=0.35,
+            backward_penalty=0.22,
+            backward_attack_penalty=0.18,
+            ball_speed_ref_m=1.2,
+            ball_speed_max_m=3.5,
+            ball_speed_skip_m=6.5,
+            carrier_tight_ref_m=0.40,
+            freeze_min_pick_score=0.66,
+            freeze_min_pass_score=0.45,
+        )
+
+
+@dataclass(frozen=True)
+class PassOption:
+    receiver_index: int
+    receiver_xy: np.ndarray
+    score: float
+    openness: float        # rival lane clearance used for scoring (m)
+    opponent_openness: float
+    teammate_openness: float
+    rivals_in_lane: int
+    teammates_in_lane: int
+    segment_opponent_openness: float  # legacy: min dist without lane filter
+    segment_teammate_openness: float
+    forward_gain: float    # raw projection onto attack direction
+    motion_alignment: float  # cos(pass, run); 0 if run unknown
+    receiver_space: float  # raw distance, receiver to nearest opponent
+    length: float
+
+
+def _rival_lane_width_steps(
+    base: float,
+    pass_length_m: float,
+    weights: PassWeights,
+) -> float:
+    """Widen rival corridor on longer passes using fixed tiers (not proportional to distance)."""
+    if pass_length_m <= weights.lane_width_mid_threshold_m:
+        return base
+    if pass_length_m <= weights.lane_width_long_threshold_m:
+        return min(weights.lane_width_max_m, base + weights.lane_width_mid_boost_m)
+    return min(weights.lane_width_max_m, base + weights.lane_width_long_boost_m)
+
+
+def _lane_width_for_pass(
+    weights: PassWeights,
+    *,
+    pass_length: float,
+    pass_length_px: float | None,
+) -> float | None:
+    """Corridor width in the units used for lane geometry (px or m)."""
+    if weights.lane_width is None or weights.lane_width <= 0:
+        return None
+    if weights.lane_in_image_space and pass_length_px is not None and pass_length > 1e-3:
+        return weights.lane_width * (pass_length_px / pass_length)
+    if not weights.lane_in_image_space:
+        return _rival_lane_width_steps(weights.lane_width, pass_length, weights)
+    return weights.lane_width
+
+
+def _teammate_lane_width(
+    weights: PassWeights, *, pass_length: float, pass_length_px: float | None
+) -> float | None:
+    base = _lane_width_for_pass(
+        weights, pass_length=pass_length, pass_length_px=pass_length_px
+    )
+    if weights.teammate_lane_width is not None:
+        if weights.lane_in_image_space and pass_length_px is not None and pass_length > 1e-3:
+            return weights.teammate_lane_width * (pass_length_px / pass_length)
+        return weights.teammate_lane_width
+    if base is not None:
+        return base * 0.5
+    return None
+
+
+def _open_ref_for_lane(weights: PassWeights, lane_width: float | None) -> float:
+    if weights.lane_in_image_space and lane_width is not None and lane_width > 0:
+        return lane_width
+    return weights.open_ref
+
+
+def _backward_motion_penalty_from_align(
+    align: float,
+    weights: PassWeights,
+) -> float:
+    """Run-direction penalty from pass·run cosine (same formula as main demo)."""
+    if weights.backward_penalty <= 0:
+        return 0.0
+    if align >= weights.backward_cos_threshold:
+        return 0.0
+    span = 1.0 - weights.backward_cos_threshold
+    severity = min(1.0, (weights.backward_cos_threshold - align) / span)
+    return weights.backward_penalty * severity
+
+
+def _backward_motion_penalty(
+    pass_delta: np.ndarray,
+    motion_dir: np.ndarray | None,
+    weights: PassWeights,
+) -> tuple[float, float]:
+    """Penalty for passes behind the carrier's run; returns (penalty, cos alignment)."""
+    if motion_dir is None or weights.backward_penalty <= 0:
+        return 0.0, 0.0
+    length = float(np.linalg.norm(pass_delta))
+    if length < 1e-6:
+        return 0.0, 0.0
+    align = float(unit(pass_delta) @ motion_dir)
+    return _backward_motion_penalty_from_align(align, weights), align
+
+
+def _backward_attack_penalty(
+    forward_gain: float,
+    attack: np.ndarray,
+    motion_dir: np.ndarray | None,
+    weights: PassWeights,
+) -> float:
+    """Penalty for passes toward own goal (negative forward gain vs attack direction)."""
+    if weights.backward_attack_penalty <= 0 or forward_gain >= 0:
+        return 0.0
+    if weights.backward_attack_only_when_running_forward:
+        if motion_dir is None:
+            return 0.0
+        if float(motion_dir @ attack) < weights.backward_attack_motion_cos_threshold:
+            return 0.0
+    severity = min(1.0, -forward_gain / weights.forward_ref)
+    return weights.backward_attack_penalty * severity
+
+
+def _teammate_lane_penalty_amount(
+    teammate_openness: float,
+    weights: PassWeights,
+    *,
+    open_ref: float,
+) -> float:
+    """Soft deduction when a teammate is in the narrow corridor (0 if none)."""
+    if weights.teammate_lane_penalty <= 0 or not np.isfinite(teammate_openness):
+        return 0.0
+    ref = weights.teammate_open_ref or open_ref
+    if ref <= 0:
+        return 0.0
+    tightness = max(0.0, 1.0 - teammate_openness / ref)
+    return weights.teammate_lane_penalty * tightness
+
+
+def score_pass_options(
+    detections: sv.Detections,
+    carrier: Carrier,
+    *,
+    weights: PassWeights = PassWeights(),
+    attack_dir: np.ndarray | None = None,
+    positions: np.ndarray | None = None,
+    carrier_motion_dir: np.ndarray | None = None,
+    body_pitch_m: np.ndarray | None = None,
+) -> list[PassOption]:
+    """Rank every teammate as a passing option (best first).
+
+    Pass *positions* (e.g. pitch coordinates in meters) to score in metric space
+    instead of image pixels. *carrier_motion_dir* is the unit run vector from recent
+    Kalman filter velocity (same coordinate system as *positions*).
+    """
+    pmask = player_mask(detections)
+    feet_img = feet_xy(detections)
+    feet = positions if positions is not None else feet_img
+    body = bbox_center_xy(detections)
+    body_lane = body_pitch_m if body_pitch_m is not None else body
+    teams = detections.data["team"]
+    use_image_lane = weights.lane_in_image_space and positions is not None
+    lane_feet = feet_img if use_image_lane else feet
+
+    teammates = pmask & (teams == carrier.team)
+    teammates[carrier.index] = False
+    opponents = pmask & (teams == (1 - carrier.team))
+
+    carrier_xy = feet[carrier.index]
+    opp_xy = feet[opponents]
+    attack = (
+        attack_direction(detections, carrier.team)
+        if attack_dir is None
+        else attack_dir
+    )
+
+    options: list[PassOption] = []
+    for idx in np.flatnonzero(teammates):
+        receiver_xy = feet[idx]
+        delta = receiver_xy - carrier_xy
+        length = float(np.linalg.norm(delta))
+        if length < 1e-6:
+            continue
+
+        pass_len_px = float(
+            np.linalg.norm(feet_img[idx] - feet_img[carrier.index])
+        )
+        lane_w = _lane_width_for_pass(
+            weights, pass_length=length, pass_length_px=pass_len_px
+        )
+        lane_kw = dict(
+            t_min=weights.lane_t_min,
+            t_max=weights.lane_t_max,
+            lane_width=lane_w,
+        )
+        team_lane_kw = {
+            **lane_kw,
+            "lane_width": _teammate_lane_width(
+                weights, pass_length=length, pass_length_px=pass_len_px
+            ),
+        }
+        lane_carrier = lane_feet[carrier.index]
+        lane_receiver = lane_feet[idx]
+        lane_opp_feet = lane_feet[opponents]
+        lane_opp_body = body_lane[opponents]
+        open_ref = _open_ref_for_lane(weights, lane_w)
+        opp_radius = None
+        if weights.lane_use_body_center and len(lane_opp_feet):
+            boxes = detections.xyxy[opponents]
+            if use_image_lane:
+                opp_radius = 0.22 * (boxes[:, 2] - boxes[:, 0])
+            elif pass_len_px > 1e-3 and length > 1e-3:
+                m_per_px = length / pass_len_px
+                opp_radius = 0.22 * (boxes[:, 2] - boxes[:, 0]) * m_per_px
+
+        if len(opp_xy):
+            if weights.use_lane_openness:
+                if weights.lane_use_body_center:
+                    opponent_openness, segment_opponent_openness = (
+                        lane_segment_clearance_body(
+                            lane_opp_feet,
+                            lane_opp_body,
+                            lane_carrier,
+                            lane_receiver,
+                            player_radius=opp_radius,
+                            **lane_kw,
+                        )
+                    )
+                    rivals_in_lane = count_lane_blockers_body(
+                        lane_opp_feet,
+                        lane_opp_body,
+                        lane_carrier,
+                        lane_receiver,
+                        player_radius=opp_radius,
+                        **lane_kw,
+                    )
+                else:
+                    opponent_openness, segment_opponent_openness = lane_segment_clearance(
+                        lane_opp_feet, lane_carrier, lane_receiver, **lane_kw
+                    )
+                    rivals_in_lane = count_lane_blockers(
+                        lane_opp_feet, lane_carrier, lane_receiver, **lane_kw
+                    )
+            else:
+                segment_opponent_openness = opponent_openness = float(
+                    point_to_segment_distance(
+                        lane_opp_feet, lane_carrier, lane_receiver
+                    ).min()
+                )
+                rivals_in_lane = len(opp_xy)
+            receiver_space = float(np.linalg.norm(opp_xy - receiver_xy, axis=1).min())
+        else:
+            opponent_openness = segment_opponent_openness = receiver_space = open_ref
+            rivals_in_lane = 0
+
+        blockers = teammates.copy()
+        blockers[carrier.index] = False
+        blockers[idx] = False
+        team_xy = lane_feet[blockers]
+        teammates_in_lane = 0
+        if len(team_xy):
+            if weights.use_lane_openness:
+                teammate_openness, segment_teammate_openness = lane_segment_clearance(
+                    team_xy, lane_carrier, lane_receiver, **team_lane_kw
+                )
+                teammates_in_lane = count_lane_blockers(
+                    team_xy, lane_carrier, lane_receiver, **team_lane_kw
+                )
+            else:
+                segment_teammate_openness = teammate_openness = float(
+                    point_to_segment_distance(
+                        team_xy, lane_carrier, lane_receiver
+                    ).min()
+                )
+                teammates_in_lane = len(team_xy)
+        else:
+            teammate_openness = segment_teammate_openness = open_ref
+
+        if weights.openness_rivals_only:
+            openness = opponent_openness
+        else:
+            openness = min(opponent_openness, teammate_openness)
+
+        forward_gain = float(delta @ attack)
+
+        n_open = min(openness / open_ref, 1.0)
+        n_space = min(receiver_space / weights.space_ref, 1.0)
+        n_forward = float(np.clip(forward_gain / weights.forward_ref, -1.0, 1.0))
+
+        score = (
+            weights.openness * n_open
+            + weights.forward * max(n_forward, 0.0)
+            + weights.space * n_space
+        )
+        tm_ref = weights.teammate_open_ref
+        if tm_ref is None:
+            tm_ref = (team_lane_kw["lane_width"] or open_ref) * 0.5
+        elif use_image_lane and length > 1e-3:
+            tm_ref = tm_ref * (pass_len_px / length)
+        score -= _teammate_lane_penalty_amount(
+            teammate_openness, weights, open_ref=tm_ref
+        )
+        back_pen, motion_align = _backward_motion_penalty(
+            delta, carrier_motion_dir, weights
+        )
+        score -= back_pen
+        score -= _backward_attack_penalty(
+            forward_gain, attack, carrier_motion_dir, weights
+        )
+        if length < weights.min_length or length > weights.max_length:
+            continue
+
+        options.append(
+            PassOption(
+                receiver_index=int(idx),
+                receiver_xy=receiver_xy,
+                score=float(score),
+                openness=openness,
+                opponent_openness=opponent_openness,
+                teammate_openness=teammate_openness,
+                segment_opponent_openness=segment_opponent_openness,
+                segment_teammate_openness=segment_teammate_openness,
+                rivals_in_lane=rivals_in_lane,
+                teammates_in_lane=teammates_in_lane,
+                forward_gain=forward_gain,
+                motion_alignment=motion_align,
+                receiver_space=receiver_space,
+                length=length,
+            )
+        )
+
+    options.sort(key=lambda o: o.score, reverse=True)
+    return options
+
+
+class PassQualityScorer:
+    """Score open teammate pass lanes for a ball carrier (alternatives only)."""
+
+    def __init__(
+        self,
+        *,
+        weights: PassWeights = PassWeights.metric(),
+        metric: bool = True,
+        transformers: dict[int, object] | None = None,
+        keypoints_by_frame: dict[int, sv.KeyPoints | None] | None = None,
+        pitch_confidence: float = 0.9,
+    ) -> None:
+        self._weights = weights
+        self._metric = metric
+        self._transformers = transformers or {}
+        self._keypoints_by_frame = keypoints_by_frame or {}
+        self._pitch_confidence = pitch_confidence
+
+    def _lane_transformer(self, frame_idx: int):
+        """Gated speed H when available; else per-frame radar fit (lane scoring only)."""
+        if not self._metric:
+            return None
+        return lane_scoring_transformer_for_frame(
+            self._transformers,
+            frame_idx,
+            self._keypoints_by_frame.get(int(frame_idx)),
+            pitch_confidence=self._pitch_confidence,
+        )
+
+    def score_options_for_carrier(
+        self,
+        frame_idx: int,
+        dets: sv.Detections,
+        carrier: Carrier,
+    ) -> list[PassOption]:
+        """Score all teammate lanes for ``carrier`` on ``frame_idx`` (best first)."""
+        motion_dir = None
+        if self._weights.use_carrier_motion:
+            transformer = self._lane_transformer(frame_idx)
+            motion_dir = carrier_kalman_direction(
+                dets,
+                carrier.index,
+                transformer=transformer if self._metric else None,
+            )
+
+        transformer = self._lane_transformer(frame_idx)
+        if self._metric and transformer is not None:
+            feet_img = feet_xy(dets)
+            pitch_feet = image_to_pitch_m(feet_img, transformer)
+            pitch_cm = image_to_pitch_cm(feet_img, transformer)
+            body_pitch_m = image_to_pitch_m(bbox_center_xy(dets), transformer)
+            if pitch_feet is None:
+                return []
+            attack_dir = attack_direction(
+                dets,
+                carrier.team,
+                transformer=transformer,
+            )
+            return score_pass_options(
+                dets,
+                carrier,
+                weights=self._weights,
+                attack_dir=attack_dir,
+                positions=pitch_feet,
+                carrier_motion_dir=motion_dir,
+                pitch_cm=pitch_cm,
+                body_pitch_m=body_pitch_m,
+            )
+        return score_pass_options(
+            dets,
+            carrier,
+            weights=self._weights,
+            carrier_motion_dir=motion_dir,
+        )
+
+    def option_for_receiver(
+        self,
+        frame_idx: int,
+        dets: sv.Detections,
+        carrier: Carrier,
+        receiver_tid: int,
+    ) -> PassOption | None:
+        """Return the scored lane to ``receiver_tid``, or None if not a teammate option."""
+        if receiver_tid < 0 or dets.tracker_id is None:
+            return None
+        pmask = player_mask(dets)
+        receiver_rows = np.flatnonzero(
+            pmask & (dets.tracker_id == receiver_tid)
+        )
+        if len(receiver_rows) == 0:
+            return None
+        receiver_index = int(receiver_rows[0])
+        for option in self.score_options_for_carrier(frame_idx, dets, carrier):
+            if option.receiver_index == receiver_index:
+                return option
+        return None
+
+    def top_options(
+        self,
+        frame_idx: int,
+        dets: sv.Detections,
+        carrier: Carrier,
+        *,
+        k: int = 3,
+    ) -> list[PassOption]:
+        """Top-``k`` teammate lanes for freeze / alternatives overlays."""
+        return self.score_options_for_carrier(frame_idx, dets, carrier)[:k]

--- a/sports/common/passes.py
+++ b/sports/common/passes.py
@@ -41,11 +41,7 @@ from dataclasses import dataclass
 import numpy as np
 import supervision as sv
 
-from sports.common.pass_pitch import (
-    attack_direction,
-    image_to_pitch_m,
-    lane_scoring_transformer_for_frame,
-)
+from sports.common.pass_pitch import image_to_pitch_m
 from sports.common.possession import (
     AERIAL_DY_THRESHOLD_PX,
     CONTROL_MAX_DISTANCE_M,

--- a/sports/common/passes.py
+++ b/sports/common/passes.py
@@ -41,7 +41,11 @@ from dataclasses import dataclass
 import numpy as np
 import supervision as sv
 
-from sports.common.pass_pitch import image_to_pitch_m
+from sports.common.pass_pitch import (
+    attack_direction,
+    image_to_pitch_m,
+    lane_scoring_transformer_for_frame,
+)
 from sports.common.possession import (
     AERIAL_DY_THRESHOLD_PX,
     CONTROL_MAX_DISTANCE_M,

--- a/sports/common/possession.py
+++ b/sports/common/possession.py
@@ -52,6 +52,57 @@ def ball_xy(detections: sv.Detections) -> np.ndarray | None:
     return np.stack([cx, cy], axis=1)[0]
 
 
+class BallPositionHistory:
+    """Recent ball ground positions for speed when picking freeze frames."""
+
+    def __init__(self, *, max_samples: int = 12) -> None:
+        self._max_samples = max_samples
+        self._samples: list[tuple[int, np.ndarray]] = []
+
+    def record(self, frame_idx: int, ball: np.ndarray | None) -> None:
+        if ball is None:
+            return
+        self._samples.append((int(frame_idx), np.asarray(ball, dtype=np.float64)))
+        if len(self._samples) > self._max_samples:
+            self._samples = self._samples[-self._max_samples :]
+
+    def speed(
+        self,
+        frame_idx: int,
+        *,
+        lookback_frames: int,
+        fps: float,
+        transformer=None,
+    ) -> float | None:
+        """Ball speed over the lookback window (m/s with homography, else px/s)."""
+        if fps <= 0 or lookback_frames < 1:
+            return None
+        window = [
+            (f, p)
+            for f, p in self._samples
+            if frame_idx - lookback_frames <= f <= frame_idx
+        ]
+        if len(window) < 2:
+            return None
+        f0, p0 = window[0]
+        f1, p1 = window[-1]
+        if f1 <= f0:
+            return None
+        dt = (f1 - f0) / fps
+        if dt <= 0:
+            return None
+
+        if transformer is not None:
+            pts = np.stack([p0, p1], axis=0).astype(np.float32)
+            pitch = image_to_pitch_m(pts, transformer)
+            if pitch is None:
+                return None
+            dist = float(np.linalg.norm(pitch[1] - pitch[0]))
+        else:
+            dist = float(np.linalg.norm(p1 - p0))
+        return dist / dt
+
+
 @dataclass(frozen=True)
 class Carrier:
     index: int          # row index into the detections

--- a/sports/common/team.py
+++ b/sports/common/team.py
@@ -74,9 +74,10 @@ class TeamClassifier:
         self.features_model = SiglipVisionModel.from_pretrained(
             SIGLIP_MODEL_PATH).to(device)
         self.processor = AutoProcessor.from_pretrained(SIGLIP_MODEL_PATH)
-        # n_jobs=1 avoids OpenMP/numba segfaults after MPS SigLIP embeddings.
-        self.reducer = umap.UMAP(n_components=3, n_jobs=1)
-        self.cluster_model = KMeans(n_clusters=2)
+        # Deterministic + single-threaded: avoids OpenMP/numba segfaults after MPS
+        # SigLIP and keeps pink/cyan assignment stable across demo renders.
+        self.reducer = umap.UMAP(n_components=3, n_jobs=1, random_state=0)
+        self.cluster_model = KMeans(n_clusters=2, n_init=10, random_state=0)
 
     def extract_features(self, crops: List[np.ndarray]) -> np.ndarray:
         """
@@ -125,6 +126,15 @@ class TeamClassifier:
                 pass
         projections = self.reducer.fit_transform(data)
         self.cluster_model.fit(projections)
+        labels = np.asarray(self.cluster_model.labels_, dtype=int)
+        counts = np.bincount(labels, minlength=2)
+        # Rare collapse: almost every crop lands in one cluster. Retry once with a
+        # different UMAP seed so demos don't paint the whole pitch one colour.
+        if len(labels) >= 20 and int(counts.min()) < max(5, int(0.12 * len(labels))):
+            self.reducer = umap.UMAP(n_components=3, n_jobs=1, random_state=1)
+            projections = self.reducer.fit_transform(data)
+            self.cluster_model = KMeans(n_clusters=2, n_init=10, random_state=1)
+            self.cluster_model.fit(projections)
         if was_mps:
             self.features_model.to(self.device)
 

--- a/sports/common/team.py
+++ b/sports/common/team.py
@@ -74,7 +74,8 @@ class TeamClassifier:
         self.features_model = SiglipVisionModel.from_pretrained(
             SIGLIP_MODEL_PATH).to(device)
         self.processor = AutoProcessor.from_pretrained(SIGLIP_MODEL_PATH)
-        self.reducer = umap.UMAP(n_components=3)
+        # n_jobs=1 avoids OpenMP/numba segfaults after MPS SigLIP embeddings.
+        self.reducer = umap.UMAP(n_components=3, n_jobs=1)
         self.cluster_model = KMeans(n_clusters=2)
 
     def extract_features(self, crops: List[np.ndarray]) -> np.ndarray:
@@ -109,8 +110,23 @@ class TeamClassifier:
             crops (List[np.ndarray]): List of image crops.
         """
         data = self.extract_features(crops)
+        # UMAP/numba can SIGSEGV while the MPS runtime is still active after
+        # SigLIP; park the vision weights on CPU for the reduce+cluster step.
+        data = np.ascontiguousarray(data, dtype=np.float64)
+        was_mps = str(self.device).startswith("mps")
+        if was_mps:
+            self.features_model.to("cpu")
+            try:
+                import torch
+
+                if hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+                    torch.mps.empty_cache()
+            except Exception:
+                pass
         projections = self.reducer.fit_transform(data)
         self.cluster_model.fit(projections)
+        if was_mps:
+            self.features_model.to(self.device)
 
     def predict(self, crops: List[np.ndarray]) -> np.ndarray:
         """

--- a/sports/common/tracking.py
+++ b/sports/common/tracking.py
@@ -331,6 +331,10 @@ def fit_team_classifier(
     """Sample frames at stride and fit TeamClassifier on player crops."""
     team_classifier = TeamClassifier(device=device)
     crops = []
+    # Dense enough sampling that short --max-frames renders still see both kits.
+    fit_stride = stride
+    if max_frames is not None and max_frames > 0:
+        fit_stride = max(1, min(stride, max(1, int(max_frames) // 40)))
     cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
     frame_idx = 0
     while True:
@@ -340,7 +344,7 @@ def fit_team_classifier(
         frame_idx += 1
         if max_frames is not None and frame_idx > max_frames:
             break
-        if frame_idx % stride != 0:
+        if frame_idx % fit_stride != 0:
             continue
         if det_by_frame is not None:
             dets = det_by_frame.get(frame_idx)

--- a/sports/common/video_tracking.py
+++ b/sports/common/video_tracking.py
@@ -31,6 +31,8 @@ from sports.common.passes import (
     PossessionScanResult,
     scan_possession_events,
 )
+from sports.common.pass_alternatives import PassEvent, plan_pass_events
+from sports.common.pass_options import PassQualityScorer, PassWeights
 from sports.common.goalkeeper import apply_goalkeeper_teams, derive_gk_locks
 from sports.common.team import (
     TeamLocks,
@@ -79,6 +81,8 @@ class VideoTrackingSession:
     _ball_by_frame: dict | None = field(default=None, repr=False)
     _pass_frames: list | None = field(default=None, repr=False)
     _pass_scan: PossessionScanResult | None = field(default=None, repr=False)
+    _pass_scorer: PassQualityScorer | None = field(default=None, repr=False)
+    _pass_alternative_events: list[PassEvent] | None = field(default=None, repr=False)
     _team_lock: TeamLocks | None = field(default=None, repr=False)
     _speed_transforms: dict | None = field(default=None, repr=False)
     _gap_filled_transforms: dict | None = field(default=None, repr=False)
@@ -253,6 +257,19 @@ class VideoTrackingSession:
     def pass_by_frame(self) -> dict[int, sv.Detections]:
         return dict(self.pass_frames())
 
+    @property
+    def pass_scorer(self) -> PassQualityScorer:
+        if self._pass_scorer is None:
+            transformers = (
+                self.gap_filled_transforms_by_frame if self.kp_by_frame else None
+            )
+            self._pass_scorer = PassQualityScorer(
+                transformers=transformers,
+                keypoints_by_frame=self.kp_by_frame,
+                pitch_confidence=0.9,
+            )
+        return self._pass_scorer
+
     def pass_scan(self) -> PossessionScanResult:
         if self._pass_scan is None:
             config = PassDetectionConfig().for_frame_rate(self.fps)
@@ -267,6 +284,30 @@ class VideoTrackingSession:
                 fps=float(self.fps),
             )
         return self._pass_scan
+
+    def pass_alternative_events(
+        self,
+        *,
+        max_events: int | None = None,
+        min_gap_frames: int = 90,
+        weights: PassWeights | None = None,
+    ) -> list[PassEvent]:
+        """Cinematic freeze moments with top teammate pass lanes."""
+        if self._pass_alternative_events is None:
+            transformers = (
+                self.gap_filled_transforms_by_frame if self.kp_by_frame else {}
+            )
+            self._pass_alternative_events = plan_pass_events(
+                self.pass_frames(),
+                fps=float(self.fps),
+                frame_transforms=transformers,
+                keypoints_by_frame=self.kp_by_frame or {},
+                scorer=self.pass_scorer,
+                weights=weights,
+                max_events=max_events,
+                min_gap_frames=min_gap_frames,
+            )
+        return self._pass_alternative_events
 
 
 def _create_player_detector_factory(args) -> Callable:


### PR DESCRIPTION
## Summary
- Lane scoring (`pass_options`) + real `PassQualityScorer` shared by detection decoration and freeze top-N
- `Mode.PASS_ALTERNATIVES` — freeze planner + rich Football AI-style lane overlays (spotlight, pulse, shaded pass corridors, receiver rings, analysis panel, radar corridors)
- `Mode.PASS_COMPLETE` / `PASS_NETWORK --show-predictions` — detected passes + freeze reveals of suggested open lanes

## Demo

### Pass alternatives (suggested lanes + corridors)
<video src="https://github.com/roboflow/sports/releases/download/soccer-analytics-pr-demos/pr8-pass-alternatives.mp4" controls width="100%"></video>

### Complete (detect + suggest)
<video src="https://github.com/roboflow/sports/releases/download/soccer-analytics-pr-demos/pr8-pass-complete.mp4" controls width="100%"></video>

[All demos](https://github.com/roboflow/sports/releases/tag/soccer-analytics-pr-demos)

## Run
```bash
# suggested lanes only
python main.py ... --mode PASS_ALTERNATIVES

# detected passes + open-lane freezes
python main.py ... --mode PASS_COMPLETE
# or: --mode PASS_NETWORK --show-predictions
```

## Test plan
- [ ] PASS_ALTERNATIVES freeze UI shows full shaded corridors (not arrows only), plus BEST/2ND/3RD chips
- [ ] Radar minimap mirrors the same corridors; red `!` marks rivals in-lane when present
- [ ] PASS_COMPLETE freezes on detected passes and reveals ranked corridors
- [ ] PASS_NETWORK without flag unchanged (no freezes)